### PR TITLE
Feature: add Excel read support, tests, docs, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,21 +15,29 @@ mvn compile
 # Package (produces JAR in target/)
 mvn package -DskipTests
 
-# Install to local Maven repository
-mvn install -DskipTests
+# Install to local Maven repository (works without GPG — signing is release-only)
+mvn clean install
 
-# Run tests (none exist yet — to be added)
+# Run all tests (JUnit 5)
 mvn test
 
-# Deploy to Maven Central (requires GPG key + OSSRH credentials)
-mvn deploy
+# Run a single test class or method
+mvn test -Dtest=ExcelServiceImplReadTest
+mvn test -Dtest=ExcelServiceImplReadTest#readDynamicExcel_sheetNotFound_throwsExcelGenerationException
+
+# Deploy + sign for Maven Central (requires GPG + Central credentials)
+mvn clean deploy -Prelease
 ```
 
 There is no linter configured. Java 8 source/target compatibility is enforced by `maven-compiler-plugin`.
 
+GPG signing lives in a `release` Maven profile, so a plain `mvn clean install` runs on machines without GPG installed. Signing only happens when `-Prelease` is passed (used for Maven Central publishing).
+
 ## Architecture
 
-### Data flow
+The library is bidirectional: it **writes** POJO lists to `.xlsx` and **reads** `.xlsx` back into POJO lists. Both directions live in `ExcelServiceImpl` and are driven by the same `ExcelHeaderBase` enum (field ⇄ display-name mapping).
+
+### Write data flow
 
 ```
 Caller
@@ -39,7 +47,7 @@ Caller
               └─► Apache POI Workbook   (XSSFWorkbook / .xlsx)
 ```
 
-`ExcelServiceImpl.generateDynamicExcelWorkbook` is the core method. All other public methods delegate to it. The flow inside that method is:
+`ExcelServiceImpl.generateDynamicExcelWorkbook` is the core write method. All other write methods delegate to it. The flow inside that method is:
 
 1. Create/reuse a `Workbook` and `Sheet`.
 2. Instantiate `StyleService` — it pre-builds default `CellStyle` objects for headers and each data type (`Merge`, `DateExcel`, `StringExcel`, `Number`).
@@ -47,11 +55,22 @@ Caller
 4. Apply column width constraints (min/max from `StyleDTO`).
 5. Optionally apply auto-filter and freeze pane.
 
+### Read data flow
+
+`ExcelServiceImpl.readDynamicExcel(Workbook, …)` is the core read method; the `byte[]` overload opens a workbook via `WorkbookFactory` and delegates to it. The flow is:
+
+1. Locate the header row: if `ExcelReadSettings.searchKeys` is non-empty, scan rows (up to `maxScanRows`) for the first row containing all keys; otherwise use `rowOffset` directly.
+2. Build a `column index → ExcelHeaderBase` map by matching header cell text to each header's **display name** (so column order in the file is irrelevant).
+3. For each data row, instantiate `dataClass` (requires a **no-args constructor**), then set each mapped field via reflection. `readCellValue` coerces the POI cell type to the target field type, resolving formulas via a `FormulaEvaluator` and unwrapping into `StringExcel`/`DateExcel`/`Number` when the field is a wrapper type (using their `fromValue` factories).
+4. Rows that are empty or fail to map are skipped (logged), not fatal.
+
 ### Key contracts
 
 **`ExcelHeaderBase`** — implemented as an enum by the caller. Each constant maps a POJO field name (`getField()`) to a display name (`getDisplayName()`) and optional per-column `StyleDTO`.
 
-**`ExcelSettings`** — configures the sheet: name, row/column offsets, custom global styles (`ExcelCustomStyles`), filter, and freeze pane.
+**`ExcelSettings`** — configures a **write**: sheet name, row/column offsets, custom global styles (`ExcelCustomStyles`), filter, and freeze pane.
+
+**`ExcelReadSettings`** — configures a **read**: sheet name, `rowOffset`/`colOffset`, `searchKeys` (locate the table by content instead of a fixed offset), and `maxScanRows`. Sheet name is required; a missing sheet or unlocatable header throws `ExcelGenerationException`.
 
 **Data type wrappers** (`DateExcel`, `StringExcel`, `Number`, `Merge`) — wrap raw values and carry an optional `StyleDTO` for per-cell styling. If a field's value is a plain Java type (`String`, `Boolean`, `Date`), it is handled directly without a wrapper.
 
@@ -76,5 +95,10 @@ Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  Exce
 - All model classes use Lombok (`@Getter`, `@Setter`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`).
 - Colors are represented via `ExcelColor` (enum) or any `ExcelColorBase` implementation, backed by XSSF RGB byte arrays.
 - POI width unit: 1 character = 256 units. Constants `DEFAULT_COLUMN_WIDTH`, `MAX_COLUMN_WIDTH`, and `DEFAULT_COLUMN_MARGIN` in `ExcelServiceImpl` control auto-sizing bounds.
-- Reflection (`getDeclaredField` + `setAccessible(true)`) is used to read private fields from data POJOs — field names in header enums must match exactly.
+- Reflection (`getDeclaredField` + `setAccessible(true)`) is used to read/write private fields on data POJOs — field names in header enums must match exactly. Read additionally requires a no-args constructor on `dataClass`.
+- All public methods throw the checked `ExcelGenerationException`; user-facing messages come from the `ResponseCode` enum.
 - The library targets Java 8; avoid using APIs introduced after Java 8.
+
+## Tests
+
+JUnit 5 (`junit-jupiter`), run by `maven-surefire-plugin`. Tests live under `src/test/java` mirroring the main package layout, split by concern: `ExcelServiceImplWriteTest`, `ExcelServiceImplReadTest`, `StyleServiceTest`, plus utility tests (`DateUtilsTest`, `ExcelUtilsTest`). Write/read tests round-trip through real in-memory POI workbooks (no mocking of POI). `src/main/.../model/dto/example/` (`ExampleDTO`, `ExcelExampleHeader`) provides reusable fixtures for both tests and documentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`excel-service` is a Java 8 library published on Maven Central that generates Excel workbooks dynamically using Apache POI. It is designed as a Spring Boot auto-configurable library — consumers inject `ExcelService` as a Spring bean and call a single method to produce an `.xlsx` file.
+
+## Build Commands
+
+```bash
+# Compile
+mvn compile
+
+# Package (produces JAR in target/)
+mvn package -DskipTests
+
+# Install to local Maven repository
+mvn install -DskipTests
+
+# Run tests (none exist yet — to be added)
+mvn test
+
+# Deploy to Maven Central (requires GPG key + OSSRH credentials)
+mvn deploy
+```
+
+There is no linter configured. Java 8 source/target compatibility is enforced by `maven-compiler-plugin`.
+
+## Architecture
+
+### Data flow
+
+```
+Caller
+  └─► ExcelService (interface)
+        └─► ExcelServiceImpl
+              ├─► StyleService          (creates/caches POI CellStyle objects)
+              └─► Apache POI Workbook   (XSSFWorkbook / .xlsx)
+```
+
+`ExcelServiceImpl.generateDynamicExcelWorkbook` is the core method. All other public methods delegate to it. The flow inside that method is:
+
+1. Create/reuse a `Workbook` and `Sheet`.
+2. Instantiate `StyleService` — it pre-builds default `CellStyle` objects for headers and each data type (`Merge`, `DateExcel`, `StringExcel`, `Number`).
+3. Write **data rows first** (via reflection on `dataClass` fields), then write the **header row last** — this is intentional so that `autoSizeColumn` is driven by data width, not header width.
+4. Apply column width constraints (min/max from `StyleDTO`).
+5. Optionally apply auto-filter and freeze pane.
+
+### Key contracts
+
+**`ExcelHeaderBase`** — implemented as an enum by the caller. Each constant maps a POJO field name (`getField()`) to a display name (`getDisplayName()`) and optional per-column `StyleDTO`.
+
+**`ExcelSettings`** — configures the sheet: name, row/column offsets, custom global styles (`ExcelCustomStyles`), filter, and freeze pane.
+
+**Data type wrappers** (`DateExcel`, `StringExcel`, `Number`, `Merge`) — wrap raw values and carry an optional `StyleDTO` for per-cell styling. If a field's value is a plain Java type (`String`, `Boolean`, `Date`), it is handled directly without a wrapper.
+
+**`StyleService`** — instantiated fresh per `generateDynamicExcelWorkbook` call because POI `CellStyle` objects are bound to a specific `Workbook` instance. It holds one default style per data type and creates new styles on demand via `getNewCellStyle` (clone → override).
+
+### Style resolution order (most specific wins)
+
+```
+Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  ExcelCustomStyles (global defaults)
+```
+
+### `Merge` type behaviour
+
+`Merge` allows merging multiple cells either vertically or horizontally. The `offset` field positions the merged cell relative to the current column index, and `range` defines how many cells to span.
+
+### Spring auto-configuration
+
+`LibAutoConfiguration` registers `ExcelServiceImpl` as a `@Lazy` bean. The auto-configuration is declared in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` for Spring Boot 2.7+ compatibility.
+
+## Conventions
+
+- All model classes use Lombok (`@Getter`, `@Setter`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`).
+- Colors are represented via `ExcelColor` (enum) or any `ExcelColorBase` implementation, backed by XSSF RGB byte arrays.
+- POI width unit: 1 character = 256 units. Constants `DEFAULT_COLUMN_WIDTH`, `MAX_COLUMN_WIDTH`, and `DEFAULT_COLUMN_MARGIN` in `ExcelServiceImpl` control auto-sizing bounds.
+- Reflection (`getDeclaredField` + `setAccessible(true)`) is used to read private fields from data POJOs — field names in header enums must match exactly.
+- The library targets Java 8; avoid using APIs introduced after Java 8.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,24 @@ There is no linter configured. Java 8 source/target compatibility is enforced by
 
 GPG signing lives in a `release` Maven profile, so a plain `mvn clean install` runs on machines without GPG installed. Signing only happens when `-Prelease` is passed (used for Maven Central publishing).
 
+## Public API
+
+`ExcelService` exposes four write overloads and two read overloads:
+
+```java
+// Write — returns byte[] or Workbook; pass an existing Workbook to add a sheet to it
+byte[]   generateDynamicExcel(headers, data, dataClass, ExcelSettings)
+byte[]   generateDynamicExcel(headers, data, dataClass, ExcelSettings, Workbook)
+Workbook generateDynamicExcelWorkbook(headers, data, dataClass, ExcelSettings)
+Workbook generateDynamicExcelWorkbook(headers, data, dataClass, ExcelSettings, Workbook)
+
+// Read — byte[] overload opens via WorkbookFactory and delegates to the Workbook overload
+<T> List<T> readDynamicExcel(byte[],    headers, Class<T>, ExcelReadSettings)
+<T> List<T> readDynamicExcel(Workbook,  headers, Class<T>, ExcelReadSettings)
+```
+
+All methods throw the checked `ExcelGenerationException`.
+
 ## Architecture
 
 The library is bidirectional: it **writes** POJO lists to `.xlsx` and **reads** `.xlsx` back into POJO lists. Both directions live in `ExcelServiceImpl` and are driven by the same `ExcelHeaderBase` enum (field ⇄ display-name mapping).
@@ -68,23 +86,21 @@ Caller
 
 **`ExcelHeaderBase`** — implemented as an enum by the caller. Each constant maps a POJO field name (`getField()`) to a display name (`getDisplayName()`) and optional per-column `StyleDTO`.
 
-**`ExcelSettings`** — configures a **write**: sheet name, row/column offsets, custom global styles (`ExcelCustomStyles`), filter, and freeze pane.
+**`ExcelSettings`** — configures a **write**: sheet name, row/column offsets, custom global styles (`ExcelCustomStyles`), filter, and freeze pane. Contains a nested `FreezePane` builder with fields `colSplit`, `rowSplit`, and optional `leftmostColumn`/`topRow` (fall back to the split values when absent).
 
-**`ExcelReadSettings`** — configures a **read**: sheet name, `rowOffset`/`colOffset`, `searchKeys` (locate the table by content instead of a fixed offset), and `maxScanRows`. Sheet name is required; a missing sheet or unlocatable header throws `ExcelGenerationException`.
+**`ExcelReadSettings`** — configures a **read**: sheet name, `rowOffset`/`colOffset`, `searchKeys` (locate the table by content instead of a fixed offset), and `maxScanRows` (`0` = unlimited). Sheet name is required; a missing sheet or unlocatable header throws `ExcelGenerationException`.
 
-**Data type wrappers** (`DateExcel`, `StringExcel`, `Number`, `Merge`) — wrap raw values and carry an optional `StyleDTO` for per-cell styling. If a field's value is a plain Java type (`String`, `Boolean`, `Date`), it is handled directly without a wrapper.
+**Data type wrappers** (`DateExcel`, `StringExcel`, `Number`, `Merge`) — wrap raw values and carry an optional `StyleDTO` for per-cell styling. Plain Java types `String`, `Boolean`, `Double`, `Integer`, `Long`, and `Date` are handled directly without a wrapper.
 
-**`StyleService`** — instantiated fresh per `generateDynamicExcelWorkbook` call because POI `CellStyle` objects are bound to a specific `Workbook` instance. It holds one default style per data type and creates new styles on demand via `getNewCellStyle` (clone → override).
+**`Merge.Orientation`** — `VERTICAL` merges rows, `HORIZONTAL` merges columns. `offset` positions the merged cell relative to the current column index; `range` defines how many cells to span.
+
+**`StyleService`** — instantiated fresh per `generateDynamicExcelWorkbook` call because POI `CellStyle` objects are bound to a specific `Workbook` instance. Not a Spring bean. It holds one default style per data type and creates new styles on demand via `getNewCellStyle` (clone → override).
 
 ### Style resolution order (most specific wins)
 
 ```
 Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  ExcelCustomStyles (global defaults)
 ```
-
-### `Merge` type behaviour
-
-`Merge` allows merging multiple cells either vertically or horizontally. The `offset` field positions the merged cell relative to the current column index, and `range` defines how many cells to span.
 
 ### Spring auto-configuration
 
@@ -93,12 +109,15 @@ Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  Exce
 ## Conventions
 
 - All model classes use Lombok (`@Getter`, `@Setter`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`).
-- Colors are represented via `ExcelColor` (enum) or any `ExcelColorBase` implementation, backed by XSSF RGB byte arrays.
+- Colors are represented via `ExcelColor` (enum, 27 constants) or any `ExcelColorBase` implementation, backed by XSSF RGB byte arrays.
 - POI width unit: 1 character = 256 units. Constants `DEFAULT_COLUMN_WIDTH`, `MAX_COLUMN_WIDTH`, and `DEFAULT_COLUMN_MARGIN` in `ExcelServiceImpl` control auto-sizing bounds.
 - Reflection (`getDeclaredField` + `setAccessible(true)`) is used to read/write private fields on data POJOs — field names in header enums must match exactly. Read additionally requires a no-args constructor on `dataClass`.
 - All public methods throw the checked `ExcelGenerationException`; user-facing messages come from the `ResponseCode` enum.
+- Default date format (`DateUtils.DEFAULT_DATE_FORMAT`) is `"yyyy/MM/dd"`.
 - The library targets Java 8; avoid using APIs introduced after Java 8.
 
 ## Tests
 
-JUnit 5 (`junit-jupiter`), run by `maven-surefire-plugin`. Tests live under `src/test/java` mirroring the main package layout, split by concern: `ExcelServiceImplWriteTest`, `ExcelServiceImplReadTest`, `StyleServiceTest`, plus utility tests (`DateUtilsTest`, `ExcelUtilsTest`). Write/read tests round-trip through real in-memory POI workbooks (no mocking of POI). `src/main/.../model/dto/example/` (`ExampleDTO`, `ExcelExampleHeader`) provides reusable fixtures for both tests and documentation.
+JUnit 5 (`junit-jupiter`), run by `maven-surefire-plugin`. Tests live under `src/test/java` mirroring the main package layout, split by concern: `ExcelServiceImplWriteTest`, `ExcelServiceImplReadTest`, `StyleServiceTest`, plus utility tests (`DateUtilsTest`, `ExcelUtilsTest`). Write/read tests round-trip through real in-memory POI workbooks (no mocking of POI).
+
+Shared fixtures in `src/main/.../model/dto/example/` (`ExampleDTO`, `ExcelExampleHeader`) are used for documentation and basic smoke tests. Each test file also defines its own local fixture DTOs and header enums for targeted scenarios: `ExcelServiceImplWriteTest` uses `BasicDTO/BasicHeader`, `AllTypesDTO/AllTypesHeader`, and `MergeDTO/MergeHeader`; `ExcelServiceImplReadTest` uses `PersonDTO/PersonHeader` and `TypedDTO/TypedHeader`.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,33 @@
 # Excel Service
 
-A Java library that generates and reads Excel workbooks dynamically using Apache POI — with a single method call.
+> Gera e lê ficheiros Excel a partir de listas de DTOs Java com uma única chamada de método — sem boilerplate, sem configuração manual do Apache POI.
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.dev-codehub/excel-service)](https://central.sonatype.com/artifact/io.github.dev-codehub/excel-service)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-
----
-
-## Table of Contents
-
-1. [Requirements](#requirements)
-2. [Technologies](#technologies)
-3. [Setup](#setup)
-4. [Features](#features)
-5. [Quick Start](#quick-start)
-6. [Writing Excel Files](#writing-excel-files)
-   - [Data Types](#data-types)
-   - [ExcelSettings](#excelsettings)
-   - [Styling](#styling)
-   - [Merging Cells](#merging-cells)
-7. [Reading Excel Files](#reading-excel-files)
-   - [ExcelReadSettings](#excelreadsettings)
-   - [Locating the Table by Keys](#locating-the-table-by-keys)
-8. [API Reference](#api-reference)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.dev-codehub/excel-service?color=1a7f37)](https://central.sonatype.com/artifact/io.github.dev-codehub/excel-service)
+[![Java](https://img.shields.io/badge/Java-8%2B-blue)](#)
+[![Apache POI](https://img.shields.io/badge/Apache%20POI-5.3.0-blue)](#)
+[![License](https://img.shields.io/badge/License-Apache%202.0-lightgrey)](http://www.apache.org/licenses/LICENSE-2.0)
 
 ---
 
-## Requirements
+## Índice
 
-- Java 8 or later
-- Spring Boot 2.x or later (auto-configuration is optional)
-
-## Technologies
-
-- Java 8
-- Spring Boot 2 (auto-configuration)
-- Apache POI 5.3.0
+- [Setup](#setup)
+- [Quick Start](#quick-start)
+- [Escrita de ficheiros Excel](#escrita-de-ficheiros-excel)
+  - [Tipos de dados](#tipos-de-dados)
+  - [ExcelSettings](#excelsettings)
+  - [Sistema de estilos](#sistema-de-estilos)
+  - [Merge de células](#merge-de-células)
+  - [Múltiplas folhas](#múltiplas-folhas)
+- [Leitura de ficheiros Excel](#leitura-de-ficheiros-excel)
+  - [ExcelReadSettings](#excelreadsettings)
+  - [Deteção automática de tabelas](#deteção-automática-de-tabelas)
+  - [Mapeamento de tipos](#mapeamento-de-tipos-na-leitura)
+- [API Reference](#api-reference)
 
 ---
 
 ## Setup
-
-Add the dependency to your `pom.xml`:
 
 ```xml
 <dependency>
@@ -51,7 +37,7 @@ Add the dependency to your `pom.xml`:
 </dependency>
 ```
 
-`ExcelService` is auto-configured as a Spring bean — inject it directly:
+A biblioteca regista-se automaticamente como bean Spring Boot — injeta diretamente:
 
 ```java
 @Service
@@ -66,111 +52,96 @@ public class ReportService {
 
 ---
 
-## Features
-
-| Feature | Description |
-|---|---|
-| Write | Generate `.xlsx` files from a list of DTOs |
-| Read | Parse `.xlsx` files back into a list of DTOs |
-| Styling | Per-cell, per-column, and global styles |
-| Merging | Horizontal and vertical cell merging |
-| Auto-filter | Enable column filter dropdowns on the header row |
-| Freeze pane | Lock rows/columns while scrolling |
-| Multiple sheets | Append new sheets to an existing workbook |
-| Table detection | Locate data tables by searching for header key words |
-
----
-
 ## Quick Start
 
-### Define your DTO
+### 1. Define o DTO
 
 ```java
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 public class PersonDTO {
-    private String name;
-    private String email;
-    private Number salary;   // use Number wrapper for numeric cells
+    private String  name;
+    private String  email;
+    private Number  salary;    // wrapper Number → célula numérica
+    private Date    birthDate; // Date → formatado como yyyy/MM/dd
+    private Boolean active;    // Boolean → célula booleana nativa
 }
 ```
 
-### Define your header enum
+### 2. Define o enum de cabeçalhos
+
+O enum implementa `ExcelHeaderBase` e mapeia cada campo do DTO ao cabeçalho visível na coluna. O `field` tem de corresponder exatamente ao nome da propriedade no DTO.
 
 ```java
 @AllArgsConstructor
 public enum PersonHeader implements ExcelHeaderBase {
-    NAME("name",   "Name",   null),
-    EMAIL("email", "Email",  null),
-    SALARY("salary", "Salary", null);
+    NAME       ("name",      "Nome",            null),
+    EMAIL      ("email",     "Email",           null),
+    SALARY     ("salary",    "Salário",         null),
+    BIRTH_DATE ("birthDate", "Data Nascimento", null),
+    ACTIVE     ("active",    "Ativo",           null);
 
-    private final String field;
-    private final String displayName;
+    private final String   field;
+    private final String   displayName;
     private final StyleDTO styles;
 
-    @Override public String getField()       { return field; }
-    @Override public String getDisplayName() { return displayName; }
-    @Override public StyleDTO getStyles()    { return styles; }
+    @Override public String   getField()       { return field; }
+    @Override public String   getDisplayName() { return displayName; }
+    @Override public StyleDTO getStyles()      { return styles; }
 }
 ```
 
-### Write
+### 3. Escreve e lê
 
 ```java
-List<PersonDTO> people = repository.findAll();
+List<ExcelHeaderBase> headers = Arrays.asList(PersonHeader.values());
 
-ExcelSettings settings = ExcelSettings.builder()
-        .sheetName("People")
-        .headerFilterActive(true)
-        .build();
-
+// Escrever
 byte[] bytes = excelService.generateDynamicExcel(
-        Arrays.asList(PersonHeader.values()), people, PersonDTO.class, settings);
-```
+        headers, personList, PersonDTO.class,
+        ExcelSettings.builder().sheetName("Pessoas").headerFilterActive(true).build());
 
-### Read
-
-```java
-ExcelReadSettings readSettings = ExcelReadSettings.builder()
-        .sheetName("People")
-        .build();
-
-List<PersonDTO> people = excelService.readDynamicExcel(
-        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+// Ler
+List<PersonDTO> pessoas = excelService.readDynamicExcel(
+        bytes, headers, PersonDTO.class,
+        ExcelReadSettings.builder().sheetName("Pessoas").build());
 ```
 
 ---
 
-## Writing Excel Files
+## Escrita de ficheiros Excel
 
-### Data Types
+### Tipos de dados
 
-| Java type | Excel cell | Notes |
+O tipo Java da propriedade no DTO determina o tipo de célula criada. Para controlo total sobre o tipo de célula ou o estilo, usa os **wrappers** da biblioteca.
+
+| Tipo Java | Tipo de célula Excel | Notas |
 |---|---|---|
-| `String` | String | Written as-is |
-| `Boolean` | Boolean | Native boolean cell |
-| `Date` | String | Formatted as `yyyy/MM/dd` |
-| `StringExcel` | String | Same as `String` but supports per-cell styling |
-| `Number` | Numeric | Use for proper numeric cells (supports formulas, sorting) |
-| `DateExcel` | String | `Date` with a custom format pattern |
-| `Merge` | String | Merges a range of cells horizontally or vertically |
-| Any other type | String | `toString()` is called |
+| `String` | Texto | Escrito diretamente |
+| `Boolean` | Booleano | Célula booleana nativa |
+| `Date` | Texto | Formatado como `yyyy/MM/dd` |
+| `StringExcel` | Texto | Igual a `String` mas com estilo por célula |
+| `Number` | Numérico | Usar para somas, fórmulas e ordenação numérica |
+| `DateExcel` | Texto | `Date` com formato personalizado |
+| `Merge` | Texto | Funde células horizontal ou verticalmente |
+| Outro qualquer | Texto | `toString()` é chamado |
 
-**`StringExcel`** — string cell with optional style:
-```java
-StringExcel.fromValue("Hello")
-StringExcel.fromValue("Hello", StyleDTO.builder().bold(true).build())
-```
+> **Atenção:** Campos `Double` nativos são escritos como células de texto. Para células numéricas com round-trip de leitura, usa o wrapper `Number`.
 
-**`Number`** — numeric cell with optional style:
-```java
-Number.fromValue(1234.56)
-Number.fromValue(1234.56, StyleDTO.builder().foregroundColor(ExcelColor.LIGHT_GREEN).build())
-```
+**Exemplos de criação dos wrappers:**
 
-**`DateExcel`** — date cell with a custom format:
 ```java
-DateExcel.fromValue(new Date(), "dd/MM/yyyy")
-DateExcel.fromValue(new Date(), "dd/MM/yyyy", myStyleDTO)
+// StringExcel — texto com estilo opcional por célula
+StringExcel.fromValue("Aprovado")
+StringExcel.fromValue("Aprovado", StyleDTO.builder().foregroundColor(ExcelColor.LIGHT_GREEN).build())
+
+// Number — célula numérica
+Number.fromValue(1_500.75)
+Number.fromValue(1_500.75, StyleDTO.builder().horizontalAlignment(HorizontalAlignment.RIGHT).build())
+
+// DateExcel — data com formato personalizado
+DateExcel.fromValue(new Date())                       // usa yyyy/MM/dd
+DateExcel.fromValue(new Date(), "dd/MM/yyyy")         // formato personalizado
+DateExcel.fromValue(new Date(), "dd/MM/yyyy", style)  // com estilo
 ```
 
 ---
@@ -179,204 +150,264 @@ DateExcel.fromValue(new Date(), "dd/MM/yyyy", myStyleDTO)
 
 ```java
 ExcelSettings settings = ExcelSettings.builder()
-        .sheetName("Report")          // required
-        .rowOffset(2)                 // first data row starts at rowOffset + 1 (default: 0)
-        .colOffset(1)                 // all columns shifted right by colOffset (default: 0)
-        .headerFilterActive(true)     // enable auto-filter on the header row
+        .sheetName("Relatório")           // obrigatório
+        .rowOffset(2)                     // cabeçalho na linha 2, dados a partir da 3
+        .colOffset(1)                     // todas as colunas avançam 1 para a direita
+        .headerFilterActive(true)         // dropdown de filtro no cabeçalho
         .freezePane(ExcelSettings.FreezePane.builder()
-                .colSplit(1)          // freeze first column
-                .rowSplit(1)          // freeze first row
+                .colSplit(1)              // congela a primeira coluna
+                .rowSplit(1)             // congela a primeira linha
                 .build())
         .excelCustomStyles(ExcelCustomStyles.builder()
                 .headerBold(true)
-                .headerBorderActive(true)
-                .headerBorderColor(ExcelColor.BLUE)
                 .fontFamily("Arial")
                 .build())
         .build();
 ```
 
-**`ExcelSettings` fields:**
-
-| Field | Type | Default | Description |
+| Campo | Tipo | Default | Descrição |
 |---|---|---|---|
-| `sheetName` | `String` | — | Sheet name (required) |
-| `rowOffset` | `int` | `0` | Row index where the header row is written |
-| `colOffset` | `int` | `0` | Column index where the first column starts |
-| `headerFilterActive` | `boolean` | `false` | Adds a dropdown filter to the header row |
-| `freezePane` | `FreezePane` | `null` | Freezes rows/columns |
-| `excelCustomStyles` | `ExcelCustomStyles` | defaults | Global style overrides |
+| `sheetName` | `String` | — | Nome da folha **(obrigatório)** |
+| `rowOffset` | `int` | `0` | Índice da linha onde o cabeçalho é escrito |
+| `colOffset` | `int` | `0` | Índice da coluna onde a primeira coluna começa |
+| `headerFilterActive` | `boolean` | `false` | Dropdown de filtro na linha de cabeçalho |
+| `freezePane` | `FreezePane` | `null` | Congela linhas e/ou colunas durante o scroll |
+| `excelCustomStyles` | `ExcelCustomStyles` | *defaults* | Estilos globais da folha |
 
 ---
 
-### Styling
+### Sistema de estilos
 
-Styles are resolved from most specific to least specific:
+Os estilos são resolvidos por especificidade — o mais específico prevalece:
 
 ```
-Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  ExcelCustomStyles (global)
+StyleDTO na célula  >  StyleDTO no cabeçalho (enum)  >  ExcelCustomStyles (global)
 ```
 
-**`StyleDTO` fields:**
+**`StyleDTO`** — controlo por célula ou por coluna:
 
-| Field | Type | Description |
+| Campo | Tipo | Descrição |
 |---|---|---|
-| `bold` | `Boolean` | Bold font |
-| `fontHeight` | `Double` | Font size in points |
-| `foregroundColor` | `ExcelColorBase` | Cell background colour |
-| `textColor` | `ExcelColorBase` | Font colour |
-| `horizontalAlignment` | `HorizontalAlignment` | POI enum (LEFT, CENTER, RIGHT…) |
-| `verticalAlignment` | `VerticalAlignment` | POI enum (TOP, CENTER, BOTTOM…) |
-| `minWidth` | `Integer` | Minimum column width in characters |
-| `maxWidth` | `Integer` | Maximum column width in characters |
+| `bold` | `Boolean` | Texto a negrito |
+| `fontHeight` | `Double` | Tamanho da fonte em pontos |
+| `foregroundColor` | `ExcelColorBase` | Cor de fundo da célula |
+| `textColor` | `ExcelColorBase` | Cor do texto |
+| `horizontalAlignment` | `HorizontalAlignment` | LEFT, CENTER, RIGHT… |
+| `verticalAlignment` | `VerticalAlignment` | TOP, CENTER, BOTTOM… |
+| `minWidth` | `Integer` | Largura mínima da coluna em caracteres |
+| `maxWidth` | `Integer` | Largura máxima da coluna em caracteres |
 
-**`ExcelCustomStyles` fields (global defaults):**
+**`ExcelCustomStyles`** — defaults globais definidos em `ExcelSettings`:
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `headerFontHeight` | `short` | `11` | Header font size |
-| `headersHeight` | `Double` | `24.0` | Header row height in points |
-| `headerBold` | `boolean` | `false` | Bold header font |
-| `headerBorderActive` | `boolean` | `true` | Show border on header cells |
-| `headerBorderColor` | `ExcelColorBase` | `BLACK` | Header border colour |
-| `dataCellFontHeight` | `short` | `11` | Data cell font size |
-| `dataCellBold` | `boolean` | `false` | Bold data font |
-| `dataBorderActive` | `boolean` | `false` | Show border on data cells |
-| `dataBorderColor` | `ExcelColorBase` | `LIGHT_GREY` | Data cell border colour |
-| `fontFamily` | `String` | `"Calibri"` | Font family for all cells |
+| Campo | Default | Descrição |
+|---|---|---|
+| `headerFontHeight` | `11` | Tamanho da fonte do cabeçalho |
+| `headersHeight` | `24.0` | Altura da linha de cabeçalho em pontos |
+| `headerBold` | `false` | Cabeçalho a negrito |
+| `headerBorderActive` | `true` | Borda nas células de cabeçalho |
+| `headerBorderColor` | `BLACK` | Cor da borda do cabeçalho |
+| `dataCellFontHeight` | `11` | Tamanho da fonte dos dados |
+| `dataCellBold` | `false` | Dados a negrito |
+| `dataBorderActive` | `false` | Borda nas células de dados |
+| `dataBorderColor` | `LIGHT_GREY` | Cor da borda dos dados |
+| `fontFamily` | `"Calibri"` | Família de fontes para todas as células |
 
-**Available colours** (`ExcelColor` enum):
+**`ExcelColor`** — cores disponíveis:
 
-`BLACK` · `BLUE` · `BLUE_ACCENT_1_LIGHTER_40` · `LIGHT_BLUE` · `BROWN` · `LIGHT_BROWN` · `LIGHT_CYAN` · `GREEN` · `LIGHT_GREEN` · `DARK_GREY` · `GREY` · `LIGHT_GREY` · `DARK_MINT` · `LIGHT_DARK_MINT` · `ORANGE` · `LIGHT_ORANGE` · `PURPLE` · `LIGHT_PURPLE` · `PINK` · `LIGHT_PINK` · `RED` · `LIGHT_RED` · `TEAL` · `LIGHT_TEAL` · `WHITE` · `YELLOW` · `LIGHT_YELLOW` · `YELLOW_BROWN` · `LIGHT_YELLOW_BROWN`
+<details>
+<summary>Ver paleta completa</summary>
 
-You can also implement `ExcelColorBase` to supply any custom RGB colour.
+| Constante | Constante | Constante |
+|---|---|---|
+| `BLACK` | `BLUE` | `BLUE_ACCENT_1_LIGHTER_40` |
+| `LIGHT_BLUE` | `BROWN` | `LIGHT_BROWN` |
+| `LIGHT_CYAN` | `GREEN` | `LIGHT_GREEN` |
+| `DARK_GREY` | `GREY` | `LIGHT_GREY` |
+| `DARK_MINT` | `LIGHT_DARK_MINT` | `ORANGE` |
+| `LIGHT_ORANGE` | `PURPLE` | `LIGHT_PURPLE` |
+| `PINK` | `LIGHT_PINK` | `RED` |
+| `LIGHT_RED` | `TEAL` | `LIGHT_TEAL` |
+| `WHITE` | `YELLOW` | `LIGHT_YELLOW` |
+| `YELLOW_BROWN` | `LIGHT_YELLOW_BROWN` | |
 
----
+Implementa `ExcelColorBase` para cores RGB personalizadas.
 
-### Merging Cells
-
-**Horizontal merge** — spans columns to the right:
-
-```java
-// Merge 3 cells horizontally, starting at the current column
-Merge.fromValue(3, 0, "Merged Header", Merge.Orientation.HORIZONTAL)
-```
-
-**Vertical merge** — spans rows downward:
-
-```java
-// Merge 2 rows vertically
-Merge.fromValue(2, 0, "Group Label", Merge.Orientation.VERTICAL)
-```
-
-`Merge.fromValue(int range, int offset, String value, Orientation orientation)`:
-- `range` — number of cells to span (must be > 1 to create a merged region)
-- `offset` — column offset relative to the current column index
-- `value` — text written in the first cell of the merged region
+</details>
 
 ---
 
-### Multiple Sheets
-
-Pass an existing `Workbook` to append a new sheet without losing previous content:
+### Merge de células
 
 ```java
-Workbook workbook = excelService.generateDynamicExcelWorkbook(
-        headers1, data1, DTO1.class, settings1);
+// Horizontal — funde 3 colunas a partir da posição atual
+Merge.fromValue(3, 0, "Dados Pessoais", Merge.Orientation.HORIZONTAL)
 
-workbook = excelService.generateDynamicExcelWorkbook(
-        headers2, data2, DTO2.class, settings2, workbook);
+// Vertical — funde 2 linhas a partir da linha atual
+Merge.fromValue(2, 0, "Grupo A", Merge.Orientation.VERTICAL)
 
-// Serialize to bytes when done
+// Com offset — começa 1 coluna à frente da posição atual do campo
+Merge.fromValue(2, 1, "Sub-cabeçalho", Merge.Orientation.HORIZONTAL)
+```
+
+| Parâmetro | Descrição |
+|---|---|
+| `range` | Número de células a fundir (> 1 para criar região fundida) |
+| `offset` | Deslocamento de coluna relativo à posição atual do campo no DTO |
+| `value` | Texto escrito na primeira célula da região fundida |
+| `orientation` | `HORIZONTAL` (expande colunas) ou `VERTICAL` (expande linhas) |
+
+---
+
+### Múltiplas folhas
+
+```java
+// Primeira folha — cria um Workbook novo
+Workbook wb = excelService.generateDynamicExcelWorkbook(
+        headers1, data1, Dto1.class,
+        ExcelSettings.builder().sheetName("Vendas").build());
+
+// Segunda folha — reutiliza o mesmo Workbook
+wb = excelService.generateDynamicExcelWorkbook(
+        headers2, data2, Dto2.class,
+        ExcelSettings.builder().sheetName("Clientes").build(), wb);
+
+// Serializar para bytes
 ByteArrayOutputStream out = new ByteArrayOutputStream();
-workbook.write(out);
-workbook.close();
+wb.write(out);
+wb.close();
 byte[] bytes = out.toByteArray();
 ```
 
 ---
 
-## Reading Excel Files
-
-Parse an `.xlsx` file back into a list of DTOs using the same header enum used to write it.
+## Leitura de ficheiros Excel
 
 ```java
-ExcelReadSettings readSettings = ExcelReadSettings.builder()
-        .sheetName("People")
+List<ExcelHeaderBase> headers = Arrays.asList(PersonHeader.values());
+
+ExcelReadSettings settings = ExcelReadSettings.builder()
+        .sheetName("Pessoas")
         .build();
 
-List<PersonDTO> people = excelService.readDynamicExcel(
-        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+List<PersonDTO> pessoas = excelService.readDynamicExcel(
+        bytes, headers, PersonDTO.class, settings);
 ```
 
-The reader maps columns by matching the **display name** of each header constant to the text found in the header row of the sheet. Only columns present in both the enum and the sheet are populated; unrecognised columns are ignored.
-
-**Cell type mapping on read:**
-
-| Excel cell type | Java field type | Result |
-|---|---|---|
-| String | `String` | String value |
-| String | `StringExcel` | `StringExcel.fromValue(...)` |
-| Numeric (integer) | `Integer` / `Long` | Cast from double |
-| Numeric (decimal) | `Double` | Raw double |
-| Numeric (decimal) | `Number` | `Number.fromValue(...)` |
-| Boolean | `Boolean` | Boolean value |
-| Formula | any | Evaluated before mapping |
-| Blank / null | any | Field left as `null` |
-
-> **Note:** Plain `Double` fields written by the library are stored as string cells (no `Number` wrapper) and cannot be read back into a `Double` field. Use the `Number` wrapper type for numeric fields that need to survive a write/read round-trip.
+A biblioteca mapeia colunas comparando o texto das células do cabeçalho com o `displayName` de cada enum. Colunas desconhecidas são ignoradas. O DTO deve ter um construtor sem argumentos.
 
 ---
 
 ### ExcelReadSettings
 
-| Field | Type | Default | Description |
+| Campo | Tipo | Default | Descrição |
 |---|---|---|---|
-| `sheetName` | `String` | — | Sheet to read (required) |
-| `rowOffset` | `int` | `0` | Row index of the header row when `searchKeys` is empty |
-| `colOffset` | `int` | `0` | Ignore columns to the left of this index |
-| `searchKeys` | `List<String>` | `[]` | Display names used to locate the header row automatically |
-| `maxScanRows` | `int` | `0` | Scan limit when using `searchKeys` (0 = no limit) |
+| `sheetName` | `String` | — | Folha a ler **(obrigatório)** |
+| `rowOffset` | `int` | `0` | Linha de cabeçalho (usado quando `searchKeys` está vazio) |
+| `colOffset` | `int` | `0` | Ignora colunas à esquerda deste índice |
+| `searchKeys` | `List<String>` | `[]` | Nomes de colunas para localizar o cabeçalho automaticamente |
+| `maxScanRows` | `int` | `0` | Limite de linhas a percorrer com `searchKeys` (0 = sem limite) |
 
 ---
 
-### Locating the Table by Keys
+### Deteção automática de tabelas
 
-When a sheet contains preamble content (titles, metadata) before the actual data table, use `searchKeys` to let the reader find the header row automatically:
+Quando a folha tem conteúdo antes da tabela (títulos, metadados), usa `searchKeys` para localizar o cabeçalho sem saber o índice da linha.
 
 ```java
-ExcelReadSettings readSettings = ExcelReadSettings.builder()
-        .sheetName("Report")
-        .searchKeys(Arrays.asList("Name", "Email", "Salary"))
-        .maxScanRows(20)   // stop scanning after 20 rows
-        .build();
+// A folha pode ter preamble antes da tabela:
+// Linha 0: "Relatório Anual"
+// Linha 1: "Gerado em: 2024-01-15"
+// Linha 2: (vazia)
+// Linha 3: "Nome" | "Email" | "Salário"  ← cabeçalho encontrado aqui
+// Linha 4+: dados
 
-List<PersonDTO> people = excelService.readDynamicExcel(
-        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+ExcelReadSettings settings = ExcelReadSettings.builder()
+        .sheetName("Pessoas")
+        .searchKeys(Arrays.asList("Nome", "Email"))  // basta um subconjunto único
+        .maxScanRows(20)                              // para após 20 linhas
+        .build();
 ```
 
-The reader scans each row until it finds one whose string cells contain **all** the specified keys. That row becomes the header row, and data is read from the next row onward. An `ExcelGenerationException` is thrown if the keys are not found within the scan limit.
+> Se as `searchKeys` não forem encontradas dentro do limite `maxScanRows`, é lançado `ExcelGenerationException`.
+
+---
+
+### Mapeamento de tipos na leitura
+
+| Célula Excel | Tipo do campo no DTO | Resultado |
+|---|---|---|
+| Texto | `String` | Valor como string |
+| Texto | `StringExcel` | `StringExcel.fromValue(...)` |
+| Numérico (inteiro) | `Integer` / `int` | Cast de double para int |
+| Numérico (inteiro) | `Long` / `long` | Cast de double para long |
+| Numérico (decimal) | `Double` / `double` | Valor double bruto |
+| Numérico | `Number` | `Number.fromValue(...)` |
+| Numérico (data) | `Date` | Data nativa |
+| Numérico (data) | `DateExcel` | `DateExcel.fromValue(...)` |
+| Booleano | `Boolean` | Valor booleano |
+| Fórmula | qualquer | Avaliada antes do mapeamento |
+| Em branco / null | qualquer | Campo fica `null` |
 
 ---
 
 ## API Reference
 
+Todos os métodos lançam `ExcelGenerationException` (checked) em caso de validação inválida, folha não encontrada ou erro de I/O.
+
+### Escrita
+
 ```java
-// Write — returns byte array
-byte[] generateDynamicExcel(headers, data, dataClass, settings) throws ExcelGenerationException;
+// Gera e devolve bytes prontos a enviar ou guardar
+byte[] generateDynamicExcel(
+    List<? extends ExcelHeaderBase> headers,
+    List<?> data,
+    Class<?> dataClass,
+    ExcelSettings settings) throws ExcelGenerationException;
 
-// Write — appends to an existing workbook
-byte[] generateDynamicExcel(headers, data, dataClass, settings, workbook) throws ExcelGenerationException;
+// Igual, mas adiciona uma nova folha a um Workbook existente
+byte[] generateDynamicExcel(
+    List<? extends ExcelHeaderBase> headers,
+    List<?> data,
+    Class<?> dataClass,
+    ExcelSettings settings,
+    Workbook workbook) throws ExcelGenerationException;
 
-// Write — returns Workbook for multi-sheet scenarios
-Workbook generateDynamicExcelWorkbook(headers, data, dataClass, settings) throws ExcelGenerationException;
-Workbook generateDynamicExcelWorkbook(headers, data, dataClass, settings, workbook) throws ExcelGenerationException;
+// Devolve o Workbook POI — útil para cenários de múltiplas folhas
+Workbook generateDynamicExcelWorkbook(
+    List<? extends ExcelHeaderBase> headers,
+    List<?> data,
+    Class<?> dataClass,
+    ExcelSettings settings) throws ExcelGenerationException;
 
-// Read — from byte array
-<T> List<T> readDynamicExcel(byte[] data, headers, dataClass, settings) throws ExcelGenerationException;
-
-// Read — from an open Workbook (caller manages lifecycle)
-<T> List<T> readDynamicExcel(Workbook workbook, headers, dataClass, settings) throws ExcelGenerationException;
+// Adiciona uma folha a um Workbook existente e devolve-o
+Workbook generateDynamicExcelWorkbook(
+    List<? extends ExcelHeaderBase> headers,
+    List<?> data,
+    Class<?> dataClass,
+    ExcelSettings settings,
+    Workbook workbook) throws ExcelGenerationException;
 ```
 
-All methods throw `ExcelGenerationException` (a checked exception) on validation errors, missing sheets, or I/O failures.
+### Leitura
+
+```java
+// Analisa bytes de um .xlsx e devolve lista de DTOs
+<T> List<T> readDynamicExcel(
+    byte[] data,
+    List<? extends ExcelHeaderBase> headers,
+    Class<T> dataClass,
+    ExcelReadSettings settings) throws ExcelGenerationException;
+
+// Analisa um Workbook já aberto (ciclo de vida é responsabilidade do chamador)
+<T> List<T> readDynamicExcel(
+    Workbook workbook,
+    List<? extends ExcelHeaderBase> headers,
+    Class<T> dataClass,
+    ExcelReadSettings settings) throws ExcelGenerationException;
+```
+
+---
+
+## Licença
+
+Distribuído sob a [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -1,104 +1,382 @@
 # Excel Service
 
-A Java library to create Excel workbooks dynamically, with a single line of code you can create an Excel workbook.
+A Java library that generates and reads Excel workbooks dynamically using Apache POI — with a single method call.
 
-Now you ask: "**That's impossible, I spend so much time and need huge amounts of code to generate an Excel!**"
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.dev-codehub/excel-service)](https://central.sonatype.com/artifact/io.github.dev-codehub/excel-service)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-Correction, you needed it, from now on it won't happen again.
+---
 
-# Table of Contents
+## Table of Contents
+
 1. [Requirements](#requirements)
-1. [Technologies](#technologies)
-1. [Features](#features)
-1. [Setup](#setup)
-1. [Examples](#examples)
+2. [Technologies](#technologies)
+3. [Setup](#setup)
+4. [Features](#features)
+5. [Quick Start](#quick-start)
+6. [Writing Excel Files](#writing-excel-files)
+   - [Data Types](#data-types)
+   - [ExcelSettings](#excelsettings)
+   - [Styling](#styling)
+   - [Merging Cells](#merging-cells)
+7. [Reading Excel Files](#reading-excel-files)
+   - [ExcelReadSettings](#excelreadsettings)
+   - [Locating the Table by Keys](#locating-the-table-by-keys)
+8. [API Reference](#api-reference)
 
-# Requirements
-- Requires Java 8 or later.
+---
 
-# Technologies
+## Requirements
+
+- Java 8 or later
+- Spring Boot 2.x or later (auto-configuration is optional)
+
+## Technologies
+
 - Java 8
-- Spring Boot 2
-- Apache POI
+- Spring Boot 2 (auto-configuration)
+- Apache POI 5.3.0
 
-# Features
-- Generate excel workbook dynamically
-- ~~Read dinamically excel files~~
+---
 
-# Setup
-1. Add dependency to your project
-   ```xml
-        <!-- Excel Service -->
-        <dependency>
-            <groupId>io.github.dev-codehub</groupId>
-            <artifactId>excel-service</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-   ```
-2. Add Excel Service to your services
-   ```java
-    class ExampleService {
-        private final ExcelService excelService;
-   
-        public ExampleService(ExcelService excelService) {
-            this.excelService = excelService;
-        }
-    }
-   ```
+## Setup
 
-# Examples:
-1. Simple Excel file with just one table and without custom styles
+Add the dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>io.github.dev-codehub</groupId>
+    <artifactId>excel-service</artifactId>
+    <version>1.0.3</version>
+</dependency>
+```
+
+`ExcelService` is auto-configured as a Spring bean — inject it directly:
+
 ```java
-    class ExampleService {
-        private final ExcelService excelService;
-   
-        public ExampleService(ExcelService excelService) {
-            this.excelService = excelService;
-        }
-   
-        public Resource generateExampleExcel() {
-            // Headers
-            List<ExcelHeaderBase> headers = List.of(ExcelExampleHeader.values());
+@Service
+public class ReportService {
+    private final ExcelService excelService;
 
-            // List of objects
-            List<ExampleDTO> exampleDTOList = repository.getExampleDTOList();
-
-            // Excel settings
-            ExcelSettings excelSettings = ExcelSettings.builder()
-                .sheetName("example")
-                // Multiple settings and styles available
-                .build();
-
-            // Generate excel
-            byte[] bytes = excelService.generateDynamicExcel(headers, exampleDTOList, ExampleDTO.class, excelSettings);
-
-            //...
-        }
+    public ReportService(ExcelService excelService) {
+        this.excelService = excelService;
     }
-    
-    @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public class ExampleDTO {
-        private String value1;
-        private String value2;
-        private Number value3;
-        private Merge value4;
-    }
-   
-    @AllArgsConstructor
-    public enum ExcelExampleHeader implements ExcelHeaderBase {
-        VALUE1("value1", "Display Column 1"),
-        VALUE2("value2", "Display Column 2"),
-        VALUE3("value3", "Display Column 3"),
-        VALUE4("value4", "Display Column 4");
-    
-        private final String field;
-        private final String displayName;
-        
-        //...
-    }
-   ```
+}
+```
 
+---
+
+## Features
+
+| Feature | Description |
+|---|---|
+| Write | Generate `.xlsx` files from a list of DTOs |
+| Read | Parse `.xlsx` files back into a list of DTOs |
+| Styling | Per-cell, per-column, and global styles |
+| Merging | Horizontal and vertical cell merging |
+| Auto-filter | Enable column filter dropdowns on the header row |
+| Freeze pane | Lock rows/columns while scrolling |
+| Multiple sheets | Append new sheets to an existing workbook |
+| Table detection | Locate data tables by searching for header key words |
+
+---
+
+## Quick Start
+
+### Define your DTO
+
+```java
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class PersonDTO {
+    private String name;
+    private String email;
+    private Number salary;   // use Number wrapper for numeric cells
+}
+```
+
+### Define your header enum
+
+```java
+@AllArgsConstructor
+public enum PersonHeader implements ExcelHeaderBase {
+    NAME("name",   "Name",   null),
+    EMAIL("email", "Email",  null),
+    SALARY("salary", "Salary", null);
+
+    private final String field;
+    private final String displayName;
+    private final StyleDTO styles;
+
+    @Override public String getField()       { return field; }
+    @Override public String getDisplayName() { return displayName; }
+    @Override public StyleDTO getStyles()    { return styles; }
+}
+```
+
+### Write
+
+```java
+List<PersonDTO> people = repository.findAll();
+
+ExcelSettings settings = ExcelSettings.builder()
+        .sheetName("People")
+        .headerFilterActive(true)
+        .build();
+
+byte[] bytes = excelService.generateDynamicExcel(
+        Arrays.asList(PersonHeader.values()), people, PersonDTO.class, settings);
+```
+
+### Read
+
+```java
+ExcelReadSettings readSettings = ExcelReadSettings.builder()
+        .sheetName("People")
+        .build();
+
+List<PersonDTO> people = excelService.readDynamicExcel(
+        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+```
+
+---
+
+## Writing Excel Files
+
+### Data Types
+
+| Java type | Excel cell | Notes |
+|---|---|---|
+| `String` | String | Written as-is |
+| `Boolean` | Boolean | Native boolean cell |
+| `Date` | String | Formatted as `yyyy/MM/dd` |
+| `StringExcel` | String | Same as `String` but supports per-cell styling |
+| `Number` | Numeric | Use for proper numeric cells (supports formulas, sorting) |
+| `DateExcel` | String | `Date` with a custom format pattern |
+| `Merge` | String | Merges a range of cells horizontally or vertically |
+| Any other type | String | `toString()` is called |
+
+**`StringExcel`** — string cell with optional style:
+```java
+StringExcel.fromValue("Hello")
+StringExcel.fromValue("Hello", StyleDTO.builder().bold(true).build())
+```
+
+**`Number`** — numeric cell with optional style:
+```java
+Number.fromValue(1234.56)
+Number.fromValue(1234.56, StyleDTO.builder().foregroundColor(ExcelColor.LIGHT_GREEN).build())
+```
+
+**`DateExcel`** — date cell with a custom format:
+```java
+DateExcel.fromValue(new Date(), "dd/MM/yyyy")
+DateExcel.fromValue(new Date(), "dd/MM/yyyy", myStyleDTO)
+```
+
+---
+
+### ExcelSettings
+
+```java
+ExcelSettings settings = ExcelSettings.builder()
+        .sheetName("Report")          // required
+        .rowOffset(2)                 // first data row starts at rowOffset + 1 (default: 0)
+        .colOffset(1)                 // all columns shifted right by colOffset (default: 0)
+        .headerFilterActive(true)     // enable auto-filter on the header row
+        .freezePane(ExcelSettings.FreezePane.builder()
+                .colSplit(1)          // freeze first column
+                .rowSplit(1)          // freeze first row
+                .build())
+        .excelCustomStyles(ExcelCustomStyles.builder()
+                .headerBold(true)
+                .headerBorderActive(true)
+                .headerBorderColor(ExcelColor.BLUE)
+                .fontFamily("Arial")
+                .build())
+        .build();
+```
+
+**`ExcelSettings` fields:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `sheetName` | `String` | — | Sheet name (required) |
+| `rowOffset` | `int` | `0` | Row index where the header row is written |
+| `colOffset` | `int` | `0` | Column index where the first column starts |
+| `headerFilterActive` | `boolean` | `false` | Adds a dropdown filter to the header row |
+| `freezePane` | `FreezePane` | `null` | Freezes rows/columns |
+| `excelCustomStyles` | `ExcelCustomStyles` | defaults | Global style overrides |
+
+---
+
+### Styling
+
+Styles are resolved from most specific to least specific:
+
+```
+Per-cell StyleDTO (on wrapper)  >  Per-column StyleDTO (on header enum)  >  ExcelCustomStyles (global)
+```
+
+**`StyleDTO` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `bold` | `Boolean` | Bold font |
+| `fontHeight` | `Double` | Font size in points |
+| `foregroundColor` | `ExcelColorBase` | Cell background colour |
+| `textColor` | `ExcelColorBase` | Font colour |
+| `horizontalAlignment` | `HorizontalAlignment` | POI enum (LEFT, CENTER, RIGHT…) |
+| `verticalAlignment` | `VerticalAlignment` | POI enum (TOP, CENTER, BOTTOM…) |
+| `minWidth` | `Integer` | Minimum column width in characters |
+| `maxWidth` | `Integer` | Maximum column width in characters |
+
+**`ExcelCustomStyles` fields (global defaults):**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `headerFontHeight` | `short` | `11` | Header font size |
+| `headersHeight` | `Double` | `24.0` | Header row height in points |
+| `headerBold` | `boolean` | `false` | Bold header font |
+| `headerBorderActive` | `boolean` | `true` | Show border on header cells |
+| `headerBorderColor` | `ExcelColorBase` | `BLACK` | Header border colour |
+| `dataCellFontHeight` | `short` | `11` | Data cell font size |
+| `dataCellBold` | `boolean` | `false` | Bold data font |
+| `dataBorderActive` | `boolean` | `false` | Show border on data cells |
+| `dataBorderColor` | `ExcelColorBase` | `LIGHT_GREY` | Data cell border colour |
+| `fontFamily` | `String` | `"Calibri"` | Font family for all cells |
+
+**Available colours** (`ExcelColor` enum):
+
+`BLACK` · `BLUE` · `BLUE_ACCENT_1_LIGHTER_40` · `LIGHT_BLUE` · `BROWN` · `LIGHT_BROWN` · `LIGHT_CYAN` · `GREEN` · `LIGHT_GREEN` · `DARK_GREY` · `GREY` · `LIGHT_GREY` · `DARK_MINT` · `LIGHT_DARK_MINT` · `ORANGE` · `LIGHT_ORANGE` · `PURPLE` · `LIGHT_PURPLE` · `PINK` · `LIGHT_PINK` · `RED` · `LIGHT_RED` · `TEAL` · `LIGHT_TEAL` · `WHITE` · `YELLOW` · `LIGHT_YELLOW` · `YELLOW_BROWN` · `LIGHT_YELLOW_BROWN`
+
+You can also implement `ExcelColorBase` to supply any custom RGB colour.
+
+---
+
+### Merging Cells
+
+**Horizontal merge** — spans columns to the right:
+
+```java
+// Merge 3 cells horizontally, starting at the current column
+Merge.fromValue(3, 0, "Merged Header", Merge.Orientation.HORIZONTAL)
+```
+
+**Vertical merge** — spans rows downward:
+
+```java
+// Merge 2 rows vertically
+Merge.fromValue(2, 0, "Group Label", Merge.Orientation.VERTICAL)
+```
+
+`Merge.fromValue(int range, int offset, String value, Orientation orientation)`:
+- `range` — number of cells to span (must be > 1 to create a merged region)
+- `offset` — column offset relative to the current column index
+- `value` — text written in the first cell of the merged region
+
+---
+
+### Multiple Sheets
+
+Pass an existing `Workbook` to append a new sheet without losing previous content:
+
+```java
+Workbook workbook = excelService.generateDynamicExcelWorkbook(
+        headers1, data1, DTO1.class, settings1);
+
+workbook = excelService.generateDynamicExcelWorkbook(
+        headers2, data2, DTO2.class, settings2, workbook);
+
+// Serialize to bytes when done
+ByteArrayOutputStream out = new ByteArrayOutputStream();
+workbook.write(out);
+workbook.close();
+byte[] bytes = out.toByteArray();
+```
+
+---
+
+## Reading Excel Files
+
+Parse an `.xlsx` file back into a list of DTOs using the same header enum used to write it.
+
+```java
+ExcelReadSettings readSettings = ExcelReadSettings.builder()
+        .sheetName("People")
+        .build();
+
+List<PersonDTO> people = excelService.readDynamicExcel(
+        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+```
+
+The reader maps columns by matching the **display name** of each header constant to the text found in the header row of the sheet. Only columns present in both the enum and the sheet are populated; unrecognised columns are ignored.
+
+**Cell type mapping on read:**
+
+| Excel cell type | Java field type | Result |
+|---|---|---|
+| String | `String` | String value |
+| String | `StringExcel` | `StringExcel.fromValue(...)` |
+| Numeric (integer) | `Integer` / `Long` | Cast from double |
+| Numeric (decimal) | `Double` | Raw double |
+| Numeric (decimal) | `Number` | `Number.fromValue(...)` |
+| Boolean | `Boolean` | Boolean value |
+| Formula | any | Evaluated before mapping |
+| Blank / null | any | Field left as `null` |
+
+> **Note:** Plain `Double` fields written by the library are stored as string cells (no `Number` wrapper) and cannot be read back into a `Double` field. Use the `Number` wrapper type for numeric fields that need to survive a write/read round-trip.
+
+---
+
+### ExcelReadSettings
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `sheetName` | `String` | — | Sheet to read (required) |
+| `rowOffset` | `int` | `0` | Row index of the header row when `searchKeys` is empty |
+| `colOffset` | `int` | `0` | Ignore columns to the left of this index |
+| `searchKeys` | `List<String>` | `[]` | Display names used to locate the header row automatically |
+| `maxScanRows` | `int` | `0` | Scan limit when using `searchKeys` (0 = no limit) |
+
+---
+
+### Locating the Table by Keys
+
+When a sheet contains preamble content (titles, metadata) before the actual data table, use `searchKeys` to let the reader find the header row automatically:
+
+```java
+ExcelReadSettings readSettings = ExcelReadSettings.builder()
+        .sheetName("Report")
+        .searchKeys(Arrays.asList("Name", "Email", "Salary"))
+        .maxScanRows(20)   // stop scanning after 20 rows
+        .build();
+
+List<PersonDTO> people = excelService.readDynamicExcel(
+        bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings);
+```
+
+The reader scans each row until it finds one whose string cells contain **all** the specified keys. That row becomes the header row, and data is read from the next row onward. An `ExcelGenerationException` is thrown if the keys are not found within the scan limit.
+
+---
+
+## API Reference
+
+```java
+// Write — returns byte array
+byte[] generateDynamicExcel(headers, data, dataClass, settings) throws ExcelGenerationException;
+
+// Write — appends to an existing workbook
+byte[] generateDynamicExcel(headers, data, dataClass, settings, workbook) throws ExcelGenerationException;
+
+// Write — returns Workbook for multi-sheet scenarios
+Workbook generateDynamicExcelWorkbook(headers, data, dataClass, settings) throws ExcelGenerationException;
+Workbook generateDynamicExcelWorkbook(headers, data, dataClass, settings, workbook) throws ExcelGenerationException;
+
+// Read — from byte array
+<T> List<T> readDynamicExcel(byte[] data, headers, dataClass, settings) throws ExcelGenerationException;
+
+// Read — from an open Workbook (caller manages lifecycle)
+<T> List<T> readDynamicExcel(Workbook workbook, headers, dataClass, settings) throws ExcelGenerationException;
+```
+
+All methods throw `ExcelGenerationException` (a checked exception) on validation errors, missing sheets, or I/O failures.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 <dependency>
     <groupId>io.github.dev-codehub</groupId>
     <artifactId>excel-service</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
 			<artifactId>spring-boot-autoconfigure</artifactId>
 			<version>2.7.18</version>
 		</dependency>
+
+		<!-- Test -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>
@@ -103,6 +111,13 @@
 
 	<build>
 		<plugins>
+			<!-- Surefire plugin for JUnit 5 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+			</plugin>
+
 			<!-- Compiler plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.dev-codehub</groupId>
 	<artifactId>excel-service</artifactId>
-	<version>1.0.3</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>Excel Service</name>
@@ -35,6 +35,8 @@
 
 	<properties>
 		<java.version>8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 
 	<dependencies>
@@ -111,6 +113,13 @@
 
 	<build>
 		<plugins>
+			<!-- Resources plugin (pinned to avoid plugin validation warnings) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+			</plugin>
+
 			<!-- Surefire plugin for JUnit 5 -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -134,6 +143,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.7.18</version>
 				<configuration>
 					<excludes>
 						<exclude>
@@ -142,22 +152,6 @@
 						</exclude>
 					</excludes>
 				</configuration>
-			</plugin>
-
-			<!-- To sign artifacts using GPG -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<!-- To include source and Javadoc JARs -->
@@ -177,7 +171,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.11.2</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -223,4 +217,31 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Release profile: signs artifacts with GPG for Maven Central deployment.
+		     Activate with -Prelease (e.g. mvn clean deploy -Prelease).
+		     A plain "mvn clean install" skips signing so it works without GPG installed. -->
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/src/main/java/io/github/devcodehub/excel/lib/config/LibAutoConfiguration.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/config/LibAutoConfiguration.java
@@ -4,10 +4,12 @@ import io.github.devcodehub.excel.lib.service.ExcelService;
 import io.github.devcodehub.excel.lib.service.ExcelServiceImpl;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 
 @AutoConfiguration
 public class LibAutoConfiguration {
     @Bean
+    @Lazy
     public ExcelService excelService() {
         return new ExcelServiceImpl();
     }

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelColor.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelColor.java
@@ -70,5 +70,5 @@ public enum ExcelColor implements ExcelColorBase {
     YELLOW_BROWN(new XSSFColor(new byte[]{(byte) 255, (byte) 192, (byte) 0})),
     LIGHT_YELLOW_BROWN(new XSSFColor(new byte[]{(byte) 255, (byte) 242, (byte) 204}));
 
-    final XSSFColor color;
+    private final XSSFColor color;
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelCustomStyles.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelCustomStyles.java
@@ -31,7 +31,7 @@ public class ExcelCustomStyles {
     @Builder.Default
     private ExcelColorBase dataBorderColor = ExcelColor.LIGHT_GREY;
     @Builder.Default
-    public String fontFamily = "Calibri";
+    private String fontFamily = "Calibri";
 
     public void setHeaderBorderColor(ExcelColorBase headerBorderColor) {
         this.headerBorderColor = headerBorderColor;

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelHeaderBase.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelHeaderBase.java
@@ -6,6 +6,6 @@ public interface ExcelHeaderBase {
     String getDisplayName();
 
     default StyleDTO getStyles() {
-        return new StyleDTO();
+        return null;
     }
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelReadSettings.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/excel/ExcelReadSettings.java
@@ -1,0 +1,39 @@
+package io.github.devcodehub.excel.lib.model.dto.excel;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExcelReadSettings {
+    private String sheetName;
+
+    @Builder.Default
+    private int rowOffset = 0;
+
+    @Builder.Default
+    private int colOffset = 0;
+
+    /**
+     * Header display names used to locate the table. When non-empty, the reader scans the sheet
+     * row by row until it finds a row containing all specified keys, and uses that as the header row.
+     * When empty, rowOffset is used as the header row index directly.
+     */
+    @Builder.Default
+    private List<String> searchKeys = Collections.emptyList();
+
+    /**
+     * Maximum number of rows to scan when using searchKeys (0 = no limit, scan entire sheet).
+     */
+    @Builder.Default
+    private int maxScanRows = 0;
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ExcelGenerationException.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ExcelGenerationException.java
@@ -1,0 +1,13 @@
+package io.github.devcodehub.excel.lib.model.dto.exception;
+
+public class ExcelGenerationException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public ExcelGenerationException(String message) {
+        super(message);
+    }
+
+    public ExcelGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
@@ -1,21 +1,23 @@
 package io.github.devcodehub.excel.lib.service;
 
-import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
 import io.github.devcodehub.excel.lib.model.dto.excel.ExcelHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
+import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
 import org.apache.poi.ss.usermodel.Workbook;
 
 import java.util.List;
 
 public interface ExcelService {
-    public byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
-                                       ExcelSettings excelSettings) throws Exception;
-    public byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
-                                       ExcelSettings excelSettings, Workbook workbook) throws Exception;
+    byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
+                                ExcelSettings excelSettings) throws ExcelGenerationException;
 
-    public Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
-                                                 Class<?> dataClass, ExcelSettings excelSettings) throws Exception;
+    byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
+                                ExcelSettings excelSettings, Workbook workbook) throws ExcelGenerationException;
 
-    public Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
-                                                 Class<?> dataClass, ExcelSettings excelSettings,
-                                                 Workbook workbook) throws Exception;
+    Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
+                                          Class<?> dataClass, ExcelSettings excelSettings) throws ExcelGenerationException;
+
+    Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
+                                          Class<?> dataClass, ExcelSettings excelSettings,
+                                          Workbook workbook) throws ExcelGenerationException;
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
@@ -1,6 +1,7 @@
 package io.github.devcodehub.excel.lib.service;
 
 import io.github.devcodehub.excel.lib.model.dto.excel.ExcelHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelReadSettings;
 import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
 import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -8,6 +9,9 @@ import org.apache.poi.ss.usermodel.Workbook;
 import java.util.List;
 
 public interface ExcelService {
+
+    // ── Write ────────────────────────────────────────────────────────────────
+
     byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
                                 ExcelSettings excelSettings) throws ExcelGenerationException;
 
@@ -20,4 +24,21 @@ public interface ExcelService {
     Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
                                           Class<?> dataClass, ExcelSettings excelSettings,
                                           Workbook workbook) throws ExcelGenerationException;
+
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Parses an Excel file from a byte array into a list of DTOs.
+     * The table is located either by a fixed row offset or by scanning for header keys,
+     * as configured in {@link ExcelReadSettings}.
+     */
+    <T> List<T> readDynamicExcel(byte[] data, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
+                                 ExcelReadSettings settings) throws ExcelGenerationException;
+
+    /**
+     * Parses an Excel sheet from an open {@link Workbook} into a list of DTOs.
+     * Caller is responsible for the workbook lifecycle.
+     */
+    <T> List<T> readDynamicExcel(Workbook workbook, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
+                                 ExcelReadSettings settings) throws ExcelGenerationException;
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelService.java
@@ -12,15 +12,60 @@ public interface ExcelService {
 
     // ── Write ────────────────────────────────────────────────────────────────
 
+    /**
+     * Generates an {@code .xlsx} workbook from a list of data objects and returns it as a byte array.
+     *
+     * @param headers      the column definitions mapping POJO field names to display names and styles
+     * @param data         the rows to write; each element must be an instance of {@code dataClass}
+     * @param dataClass    the class of the data objects, used to read field values via reflection
+     * @param excelSettings the sheet configuration (name, offsets, styles, filter, freeze pane)
+     * @return the generated workbook serialized as a byte array
+     * @throws ExcelGenerationException if the workbook cannot be built or serialized
+     */
     byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
                                 ExcelSettings excelSettings) throws ExcelGenerationException;
 
+    /**
+     * Generates a sheet from a list of data objects into an existing workbook and returns the result
+     * as a byte array. Use this to write multiple sheets into the same file.
+     *
+     * @param headers      the column definitions mapping POJO field names to display names and styles
+     * @param data         the rows to write; each element must be an instance of {@code dataClass}
+     * @param dataClass    the class of the data objects, used to read field values via reflection
+     * @param excelSettings the sheet configuration (name, offsets, styles, filter, freeze pane)
+     * @param workbook     the existing workbook to add the sheet to
+     * @return the resulting workbook serialized as a byte array
+     * @throws ExcelGenerationException if the workbook cannot be built or serialized
+     */
     byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
                                 ExcelSettings excelSettings, Workbook workbook) throws ExcelGenerationException;
 
+    /**
+     * Generates an {@code .xlsx} workbook from a list of data objects and returns the live
+     * {@link Workbook} instance, leaving serialization and lifecycle to the caller.
+     *
+     * @param headers      the column definitions mapping POJO field names to display names and styles
+     * @param data         the rows to write; each element must be an instance of {@code dataClass}
+     * @param dataClass    the class of the data objects, used to read field values via reflection
+     * @param excelSettings the sheet configuration (name, offsets, styles, filter, freeze pane)
+     * @return the generated {@link Workbook}
+     * @throws ExcelGenerationException if the workbook cannot be built
+     */
     Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
                                           Class<?> dataClass, ExcelSettings excelSettings) throws ExcelGenerationException;
 
+    /**
+     * Adds a sheet built from a list of data objects to an existing workbook and returns the same
+     * {@link Workbook} instance. This is the core method all other write methods delegate to.
+     *
+     * @param headers      the column definitions mapping POJO field names to display names and styles
+     * @param data         the rows to write; each element must be an instance of {@code dataClass}
+     * @param dataClass    the class of the data objects, used to read field values via reflection
+     * @param excelSettings the sheet configuration (name, offsets, styles, filter, freeze pane)
+     * @param workbook     the existing workbook to add the sheet to
+     * @return the same {@link Workbook} with the new sheet added
+     * @throws ExcelGenerationException if the workbook cannot be built
+     */
     Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
                                           Class<?> dataClass, ExcelSettings excelSettings,
                                           Workbook workbook) throws ExcelGenerationException;
@@ -31,6 +76,14 @@ public interface ExcelService {
      * Parses an Excel file from a byte array into a list of DTOs.
      * The table is located either by a fixed row offset or by scanning for header keys,
      * as configured in {@link ExcelReadSettings}.
+     *
+     * @param <T>       the type of the DTO produced for each row
+     * @param data      the raw {@code .xlsx} file contents
+     * @param headers   the column definitions mapping display names back to POJO field names
+     * @param dataClass the class to instantiate and populate for each row
+     * @param settings  the read configuration (sheet, header location strategy, offsets)
+     * @return the parsed rows as a list of {@code dataClass} instances
+     * @throws ExcelGenerationException if the file cannot be read or mapped to {@code dataClass}
      */
     <T> List<T> readDynamicExcel(byte[] data, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
                                  ExcelReadSettings settings) throws ExcelGenerationException;
@@ -38,6 +91,14 @@ public interface ExcelService {
     /**
      * Parses an Excel sheet from an open {@link Workbook} into a list of DTOs.
      * Caller is responsible for the workbook lifecycle.
+     *
+     * @param <T>       the type of the DTO produced for each row
+     * @param workbook  the open workbook to read from
+     * @param headers   the column definitions mapping display names back to POJO field names
+     * @param dataClass the class to instantiate and populate for each row
+     * @param settings  the read configuration (sheet, header location strategy, offsets)
+     * @return the parsed rows as a list of {@code dataClass} instances
+     * @throws ExcelGenerationException if the sheet cannot be read or mapped to {@code dataClass}
      */
     <T> List<T> readDynamicExcel(Workbook workbook, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
                                  ExcelReadSettings settings) throws ExcelGenerationException;

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
@@ -7,6 +7,7 @@ import io.github.devcodehub.excel.lib.model.dto.excel.datatype.DateExcel;
 import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Merge;
 import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Number;
 import io.github.devcodehub.excel.lib.model.dto.excel.datatype.StringExcel;
+import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
 import io.github.devcodehub.excel.lib.model.dto.exception.ResponseCode;
 import io.github.devcodehub.excel.lib.utils.DateUtils;
 import org.apache.poi.ss.usermodel.Cell;
@@ -35,47 +36,45 @@ public class ExcelServiceImpl implements ExcelService {
     private static final int DEFAULT_COLUMN_WIDTH = 10 * POI_DEFAULT_UNIT;
     private static final int MAX_COLUMN_WIDTH = 255 * POI_DEFAULT_UNIT;
     private static final int DEFAULT_COLUMN_MARGIN = 5 * POI_DEFAULT_UNIT;
+
     private final Logger log = LoggerFactory.getLogger(this.getClass());
-    private StyleService styleService;
 
     @Override
     public byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
-                                       ExcelSettings excelSettings) throws Exception {
+                                       ExcelSettings excelSettings) throws ExcelGenerationException {
         return generateDynamicExcel(headers, data, dataClass, excelSettings, null);
     }
 
     @Override
     public byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
-                                       ExcelSettings excelSettings, Workbook workbook) throws Exception {
-        try (Workbook generatedWorkbook = generateDynamicExcelWorkbook(headers, data, dataClass, excelSettings, workbook)) {
-            if (generatedWorkbook != null) {
-                // Convert workbook into a byte array
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                generatedWorkbook.write(outputStream);
-                return outputStream.toByteArray();
-            }
+                                       ExcelSettings excelSettings, Workbook workbook) throws ExcelGenerationException {
+        try (Workbook generatedWorkbook = generateDynamicExcelWorkbook(headers, data, dataClass, excelSettings, workbook);
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            generatedWorkbook.write(outputStream);
+            return outputStream.toByteArray();
+        } catch (ExcelGenerationException e) {
+            throw e;
         } catch (IOException e) {
-            log.error("Error generating dynamic excel!", e);
+            log.error("Error writing excel to output stream!", e);
+            throw new ExcelGenerationException(ResponseCode.ERROR_GENERATING_DYNAMIC_EXCEL.getMessage(), e);
         }
-
-        throw new Exception(ResponseCode.ERROR_GENERATING_DYNAMIC_EXCEL.getMessage());
     }
 
     @Override
     public Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
-                                                 Class<?> dataClass, ExcelSettings excelSettings) throws Exception {
+                                                 Class<?> dataClass, ExcelSettings excelSettings) throws ExcelGenerationException {
         return generateDynamicExcelWorkbook(headers, data, dataClass, excelSettings, null);
     }
 
     @Override
     public Workbook generateDynamicExcelWorkbook(List<? extends ExcelHeaderBase> headers, List<?> data,
                                                  Class<?> dataClass, ExcelSettings excelSettings,
-                                                 Workbook workbook) throws Exception {
+                                                 Workbook workbook) throws ExcelGenerationException {
         String sheetName = excelSettings.getSheetName();
         log.info("Generating dynamic excel - Sheet name [{}]", sheetName);
 
         if (sheetName == null) {
-            throw new Exception("Sheet name must not be null. It must be defined in ExcelSettings.");
+            throw new ExcelGenerationException("Sheet name must not be null. It must be defined in ExcelSettings.");
         }
 
         try {
@@ -86,12 +85,13 @@ public class ExcelServiceImpl implements ExcelService {
             if (sheet == null)
                 sheet = workbook.createSheet(sheetName);
 
-            // This new instance of the service is necessary because we need to send the created workbook to get new styles from it
-            styleService = new StyleService(workbook, excelSettings.getExcelCustomStyles());
+            // StyleService is instantiated per call because POI CellStyle objects are bound to a specific Workbook instance
+            StyleService styleService = new StyleService(workbook, excelSettings.getExcelCustomStyles());
 
-            // Create data rows
             int rowOffset = excelSettings.getRowOffset();
             int colOffset = excelSettings.getColOffset();
+
+            // Create data rows
             int rowIndex = rowOffset + 1;
             for (Object dto : data) {
                 Row dataRow = sheet.createRow(rowIndex++);
@@ -99,35 +99,27 @@ public class ExcelServiceImpl implements ExcelService {
 
                 for (ExcelHeaderBase header : headers) {
                     Field field = dataClass.getDeclaredField(header.getField());
-                    field.setAccessible(true); // This is required to access private fields, otherwise it will throw IllegalAccessException
+                    field.setAccessible(true);
                     Object value = field.get(dto);
 
                     if (value != null) {
                         Cell cell = dataRow.createCell(colIndex);
-                        setObjectCellValue(cell, value, sheet, rowIndex - 1, colIndex, workbook);
+                        setObjectCellValue(cell, value, sheet, rowIndex - 1, colIndex, workbook, styleService);
                     }
                     if (header.getDisplayName() != null)
                         colIndex++;
                 }
             }
 
-            // Auto size columns width
-            for (int colNum = colOffset; colNum < (headers.size() + colOffset); colNum++) {
+            // Auto-size columns.
+            // Note: Headers are created after data rows so that auto-sizing is driven by data width, not header width.
+            for (int colNum = colOffset; colNum < headers.size() + colOffset; colNum++) {
                 sheet.autoSizeColumn(colNum);
-
-                // Check if this column has minimum width defined on this specific header Enum
                 StyleDTO styles = headers.get(colNum - colOffset).getStyles();
-                int defaultColumnWidth = styles != null && styles.getMinWidth() != null ? styles.getMinWidth() * POI_DEFAULT_UNIT :
-                        DEFAULT_COLUMN_WIDTH;
-
-                // Force width (apache poi default unit of a character is 256)
-                sheet.setColumnWidth(colNum, Math.min(styles != null && styles.getMaxWidth() != null ?
-                                Math.min(MAX_COLUMN_WIDTH, (styles.getMaxWidth() * POI_DEFAULT_UNIT)) : MAX_COLUMN_WIDTH,
-                        DEFAULT_COLUMN_MARGIN + Math.max(defaultColumnWidth, sheet.getColumnWidth(colNum))));
+                sheet.setColumnWidth(colNum, calculateColumnWidth(sheet.getColumnWidth(colNum), styles));
             }
 
-            // Create header row.
-            // Note: The headers are created after data rows, so that the auto columns size doesn't take header's width into account
+            // Create header row
             Row headerRow = sheet.createRow(rowOffset);
             int colIndex = colOffset;
             for (ExcelHeaderBase header : headers) {
@@ -137,24 +129,19 @@ public class ExcelServiceImpl implements ExcelService {
                     cell.setCellValue(headerDisplayName);
 
                     StyleDTO styles = header.getStyles();
-                    if (styles != null) {
-                        CellStyle customHeaderCellStyle = styleService.getHeaderCellStyle(workbook, styles);
-                        cell.setCellStyle(customHeaderCellStyle);
-                    } else {
-                        cell.setCellStyle(styleService.getHeaderCellStyle());
-                    }
+                    CellStyle headerStyle = styles != null
+                            ? styleService.getHeaderCellStyle(workbook, styles)
+                            : styleService.getHeaderCellStyle();
+                    cell.setCellStyle(headerStyle);
                 }
             }
 
-            // Set headers height
             if (excelSettings.getExcelCustomStyles().getHeadersHeight() != null)
                 headerRow.setHeightInPoints(excelSettings.getExcelCustomStyles().getHeadersHeight().floatValue());
 
-            // Set header filters
             if (excelSettings.isHeaderFilterActive())
-                sheet.setAutoFilter(new CellRangeAddress(rowOffset, rowOffset, colOffset, headers.size()));
+                sheet.setAutoFilter(new CellRangeAddress(rowOffset, rowOffset, colOffset, colOffset + headers.size() - 1));
 
-            // Set freeze pane
             ExcelSettings.FreezePane freezePane = excelSettings.getFreezePane();
             if (freezePane != null)
                 sheet.createFreezePane(freezePane.getColSplit(), freezePane.getRowSplit(), freezePane.getLeftmostColumn(), freezePane.getTopRow());
@@ -162,21 +149,29 @@ public class ExcelServiceImpl implements ExcelService {
             return workbook;
         } catch (ReflectiveOperationException e) {
             log.error("Error generating dynamic excel sheet! Sheet name [{}]", sheetName, e);
+            throw new ExcelGenerationException(ResponseCode.ERROR_GENERATING_DYNAMIC_EXCEL.getMessage(), e);
         }
-
-        throw new Exception(ResponseCode.ERROR_GENERATING_DYNAMIC_EXCEL.getMessage());
     }
 
+    private int calculateColumnWidth(int autoSizedWidth, StyleDTO styles) {
+        int minWidth = styles != null && styles.getMinWidth() != null
+                ? styles.getMinWidth() * POI_DEFAULT_UNIT
+                : DEFAULT_COLUMN_WIDTH;
+        int maxWidth = styles != null && styles.getMaxWidth() != null
+                ? Math.min(MAX_COLUMN_WIDTH, styles.getMaxWidth() * POI_DEFAULT_UNIT)
+                : MAX_COLUMN_WIDTH;
+        return Math.min(maxWidth, DEFAULT_COLUMN_MARGIN + Math.max(minWidth, autoSizedWidth));
+    }
 
-    private void setObjectCellValue(Cell cell, Object value, Sheet sheet, int rowIndex, int colIndex, Workbook workbook) {
-        // Default style, this can change depending on the column type bellow
+    private void setObjectCellValue(Cell cell, Object value, Sheet sheet, int rowIndex, int colIndex,
+                                    Workbook workbook, StyleService styleService) {
         cell.setCellStyle(styleService.getDataCellStyle());
 
         if (value instanceof Date) {
             cell.setCellValue(DateUtils.getDateAsString((Date) value));
         } else if (value instanceof DateExcel) {
             DateExcel dateExcel = (DateExcel) value;
-            cell.setCellValue(dateExcel.getValue());
+            cell.setCellValue(DateUtils.getDateAsString(dateExcel.getValue(), dateExcel.getFormat()));
             cell.setCellStyle(styleService.getCellStyle(workbook, DateExcel.class, dateExcel.getStyles()));
         } else if (value instanceof StringExcel) {
             StringExcel stringExcel = (StringExcel) value;
@@ -193,26 +188,20 @@ public class ExcelServiceImpl implements ExcelService {
             String cellValue = merge.getValue();
             if (StringUtils.hasLength(cellValue)) {
                 if (merge.getRange() > 1) {
-                    switch (merge.getOrientation()) {
-                        case VERTICAL:
-                            sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex + merge.getRange() - 1, colIndex + merge.getOffset(),
-                                    colIndex + merge.getOffset()));
-                            break;
-                        case HORIZONTAL:
-                            sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex, colIndex + merge.getOffset(),
-                                    colIndex + merge.getOffset() + merge.getRange() - 1));
-                            break;
-                        default:
-                            break;
+                    if (merge.getOrientation() == Merge.Orientation.VERTICAL) {
+                        sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex + merge.getRange() - 1,
+                                colIndex + merge.getOffset(), colIndex + merge.getOffset()));
+                    } else if (merge.getOrientation() == Merge.Orientation.HORIZONTAL) {
+                        sheet.addMergedRegion(new CellRangeAddress(rowIndex, rowIndex,
+                                colIndex + merge.getOffset(), colIndex + merge.getOffset() + merge.getRange() - 1));
                     }
                 }
-
                 cell = sheet.getRow(rowIndex).createCell(colIndex + merge.getOffset());
                 cell.setCellValue(cellValue);
                 cell.setCellStyle(styleService.getCellStyle(workbook, Merge.class, merge.getStyles()));
             }
         } else {
-            cell.setCellValue(value == null ? "" : value.toString());
+            cell.setCellValue(value.toString());
         }
     }
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
@@ -1,6 +1,7 @@
 package io.github.devcodehub.excel.lib.service;
 
 import io.github.devcodehub.excel.lib.model.dto.excel.ExcelHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelReadSettings;
 import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
 import io.github.devcodehub.excel.lib.model.dto.excel.StyleDTO;
 import io.github.devcodehub.excel.lib.model.dto.excel.datatype.DateExcel;
@@ -12,9 +13,13 @@ import io.github.devcodehub.excel.lib.model.dto.exception.ResponseCode;
 import io.github.devcodehub.excel.lib.utils.DateUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
@@ -23,11 +28,17 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Lazy
 @Service
@@ -38,6 +49,8 @@ public class ExcelServiceImpl implements ExcelService {
     private static final int DEFAULT_COLUMN_MARGIN = 5 * POI_DEFAULT_UNIT;
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    // ── Write ─────────────────────────────────────────────────────────────────
 
     @Override
     public byte[] generateDynamicExcel(List<? extends ExcelHeaderBase> headers, List<?> data, Class<?> dataClass,
@@ -203,5 +216,195 @@ public class ExcelServiceImpl implements ExcelService {
         } else {
             cell.setCellValue(value.toString());
         }
+    }
+
+    // ── Read ──────────────────────────────────────────────────────────────────
+
+    @Override
+    public <T> List<T> readDynamicExcel(byte[] data, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
+                                        ExcelReadSettings settings) throws ExcelGenerationException {
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(data))) {
+            return readDynamicExcel(workbook, headers, dataClass, settings);
+        } catch (ExcelGenerationException e) {
+            throw e;
+        } catch (IOException e) {
+            log.error("Error opening excel from byte array!", e);
+            throw new ExcelGenerationException("Error opening excel file.", e);
+        }
+    }
+
+    @Override
+    public <T> List<T> readDynamicExcel(Workbook workbook, List<? extends ExcelHeaderBase> headers, Class<T> dataClass,
+                                        ExcelReadSettings settings) throws ExcelGenerationException {
+        String sheetName = settings.getSheetName();
+        if (sheetName == null) {
+            throw new ExcelGenerationException("Sheet name must not be null in ExcelReadSettings.");
+        }
+
+        Sheet sheet = workbook.getSheet(sheetName);
+        if (sheet == null) {
+            throw new ExcelGenerationException("Sheet not found: " + sheetName);
+        }
+
+        try {
+            dataClass.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new ExcelGenerationException(dataClass.getName() + " must have a no-args constructor.", e);
+        }
+
+        int headerRowIndex;
+        List<String> searchKeys = settings.getSearchKeys();
+        if (!searchKeys.isEmpty()) {
+            headerRowIndex = findHeaderRow(sheet, searchKeys, settings.getColOffset(), settings.getMaxScanRows());
+            if (headerRowIndex < 0) {
+                throw new ExcelGenerationException("Could not find table header containing keys: " + searchKeys);
+            }
+            log.info("Found table header at row {} in sheet '{}'", headerRowIndex, sheetName);
+        } else {
+            headerRowIndex = settings.getRowOffset();
+        }
+
+        Row headerRow = sheet.getRow(headerRowIndex);
+        if (headerRow == null) {
+            throw new ExcelGenerationException("Header row is empty at row index: " + headerRowIndex);
+        }
+
+        Map<Integer, ExcelHeaderBase> columnMapping = buildColumnMapping(headerRow, headers, settings.getColOffset());
+        if (columnMapping.isEmpty()) {
+            log.warn("No columns matched the provided headers in sheet '{}'. Returning empty list.", sheetName);
+            return new ArrayList<>();
+        }
+
+        FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+        List<T> result = new ArrayList<>();
+
+        for (int rowIdx = headerRowIndex + 1; rowIdx <= sheet.getLastRowNum(); rowIdx++) {
+            Row row = sheet.getRow(rowIdx);
+            if (row == null || isRowEmpty(row)) continue;
+
+            try {
+                T instance = dataClass.getDeclaredConstructor().newInstance();
+                boolean hasData = false;
+
+                for (Map.Entry<Integer, ExcelHeaderBase> entry : columnMapping.entrySet()) {
+                    Cell cell = row.getCell(entry.getKey());
+                    Field field = dataClass.getDeclaredField(entry.getValue().getField());
+                    field.setAccessible(true);
+                    Object value = readCellValue(cell, field, evaluator);
+                    if (value != null) {
+                        field.set(instance, value);
+                        hasData = true;
+                    }
+                }
+
+                if (hasData) result.add(instance);
+            } catch (ReflectiveOperationException e) {
+                log.warn("Skipping row {}: could not map to {}", rowIdx, dataClass.getSimpleName(), e);
+            }
+        }
+
+        log.info("Read {} rows from sheet '{}'", result.size(), sheetName);
+        return result;
+    }
+
+    /**
+     * Scans the sheet row by row to find the first row that contains all searchKeys as cell values.
+     * Returns the row index, or -1 if not found within the scan limit.
+     */
+    private int findHeaderRow(Sheet sheet, List<String> searchKeys, int colOffset, int maxScanRows) {
+        int limit = maxScanRows > 0 ? Math.min(maxScanRows, sheet.getLastRowNum() + 1) : sheet.getLastRowNum() + 1;
+        Set<String> keys = new HashSet<>(searchKeys);
+
+        for (int i = 0; i < limit; i++) {
+            Row row = sheet.getRow(i);
+            if (row == null) continue;
+
+            Set<String> cellValues = new HashSet<>();
+            for (Cell cell : row) {
+                if (cell.getColumnIndex() >= colOffset && cell.getCellType() == CellType.STRING) {
+                    cellValues.add(cell.getStringCellValue().trim());
+                }
+            }
+            if (cellValues.containsAll(keys)) return i;
+        }
+        return -1;
+    }
+
+    /**
+     * Builds a map of column index → ExcelHeaderBase by matching each header cell's string value
+     * to the display names of the provided headers.
+     */
+    private Map<Integer, ExcelHeaderBase> buildColumnMapping(Row headerRow, List<? extends ExcelHeaderBase> headers,
+                                                             int colOffset) {
+        Map<String, ExcelHeaderBase> byDisplayName = new HashMap<>();
+        for (ExcelHeaderBase header : headers) {
+            if (header.getDisplayName() != null) {
+                byDisplayName.put(header.getDisplayName(), header);
+            }
+        }
+
+        Map<Integer, ExcelHeaderBase> columnMapping = new HashMap<>();
+        for (Cell cell : headerRow) {
+            if (cell.getColumnIndex() < colOffset || cell.getCellType() != CellType.STRING) continue;
+            ExcelHeaderBase header = byDisplayName.get(cell.getStringCellValue().trim());
+            if (header != null) {
+                columnMapping.put(cell.getColumnIndex(), header);
+            }
+        }
+        return columnMapping;
+    }
+
+    /**
+     * Reads a cell's value and converts it to the type expected by the target field.
+     * Supports String, Double, Integer, Long, Boolean, Date and the library's wrapper types.
+     */
+    private Object readCellValue(Cell cell, Field field, FormulaEvaluator evaluator) {
+        if (cell == null) return null;
+
+        CellType effectiveType = cell.getCellType();
+        if (effectiveType == CellType.FORMULA) {
+            effectiveType = evaluator.evaluateFormulaCell(cell);
+        }
+
+        Class<?> fieldType = field.getType();
+
+        switch (effectiveType) {
+            case STRING: {
+                String value = cell.getStringCellValue().trim();
+                if (value.isEmpty()) return null;
+                if (fieldType == StringExcel.class) return StringExcel.fromValue(value);
+                return value;
+            }
+            case NUMERIC: {
+                if (DateUtil.isCellDateFormatted(cell)) {
+                    Date value = cell.getDateCellValue();
+                    if (fieldType == DateExcel.class) return DateExcel.fromValue(value);
+                    return value;
+                }
+                double value = cell.getNumericCellValue();
+                if (fieldType == Number.class) return Number.fromValue(value);
+                if (fieldType == Integer.class || fieldType == int.class) return (int) value;
+                if (fieldType == Long.class || fieldType == long.class) return (long) value;
+                if (fieldType == String.class || fieldType == StringExcel.class) {
+                    String str = value % 1 == 0 ? String.valueOf((long) value) : String.valueOf(value);
+                    return fieldType == StringExcel.class ? StringExcel.fromValue(str) : str;
+                }
+                return value;
+            }
+            case BOOLEAN:
+                return cell.getBooleanCellValue();
+            case BLANK:
+            default:
+                return null;
+        }
+    }
+
+    private boolean isRowEmpty(Row row) {
+        for (Cell cell : row) {
+            if (cell == null || cell.getCellType() == CellType.BLANK) continue;
+            if (cell.getCellType() != CellType.STRING) return false;
+            if (!cell.getStringCellValue().trim().isEmpty()) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/service/StyleService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/StyleService.java
@@ -16,12 +16,15 @@ import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.extensions.XSSFCellBorder;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class StyleService {
-    public static final List<XSSFCellBorder.BorderSide> BORDER_SIDES = Arrays.asList(XSSFCellBorder.BorderSide.TOP, XSSFCellBorder.BorderSide.BOTTOM, XSSFCellBorder.BorderSide.LEFT, XSSFCellBorder.BorderSide.RIGHT);
+    public static final List<XSSFCellBorder.BorderSide> BORDER_SIDES = Collections.unmodifiableList(
+            Arrays.asList(XSSFCellBorder.BorderSide.TOP, XSSFCellBorder.BorderSide.BOTTOM,
+                    XSSFCellBorder.BorderSide.LEFT, XSSFCellBorder.BorderSide.RIGHT));
 
     @Getter
     private final CellStyle headerCellStyle;

--- a/src/main/java/io/github/devcodehub/excel/lib/utils/DateUtils.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/utils/DateUtils.java
@@ -1,7 +1,7 @@
 package io.github.devcodehub.excel.lib.utils;
 
-import java.text.Format;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 public class DateUtils {
@@ -15,7 +15,7 @@ public class DateUtils {
         if (date == null) {
             return null;
         }
-        Format formatter = new SimpleDateFormat(pattern);
-        return formatter.format(date);
+        return DateTimeFormatter.ofPattern(pattern)
+                .format(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     }
 }

--- a/src/test/java/io/github/devcodehub/excel/lib/service/ExcelServiceImplReadTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/service/ExcelServiceImplReadTest.java
@@ -1,0 +1,539 @@
+package io.github.devcodehub.excel.lib.service;
+
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelReadSettings;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
+import io.github.devcodehub.excel.lib.model.dto.excel.StyleDTO;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.DateExcel;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Number;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.StringExcel;
+import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExcelServiceImplReadTest {
+
+    private ExcelServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExcelServiceImpl();
+    }
+
+    // ── DTOs ──────────────────────────────────────────────────────────────────
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class PersonDTO {
+        private String name;
+        private Double amount;
+    }
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class TypedDTO {
+        private String strField;
+        private Integer intField;
+        private Long longField;
+        private Boolean boolField;
+        private StringExcel stringExcelField;
+        private Number numberField;
+    }
+
+    static class NoDefaultConstructorDTO {
+        NoDefaultConstructorDTO(String unused) {}
+    }
+
+    // ── Headers ───────────────────────────────────────────────────────────────
+
+    @AllArgsConstructor
+    enum PersonHeader implements ExcelHeaderBase {
+        NAME("name", "Name", null),
+        AMOUNT("amount", "Amount", null);
+        private final String field;
+        private final String displayName;
+        private final StyleDTO styles;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+        @Override public StyleDTO getStyles() { return styles; }
+    }
+
+    @AllArgsConstructor
+    enum TypedHeader implements ExcelHeaderBase {
+        STR_FIELD("strField", "StrField", null),
+        INT_FIELD("intField", "IntField", null),
+        LONG_FIELD("longField", "LongField", null),
+        BOOL_FIELD("boolField", "BoolField", null),
+        STRING_EXCEL_FIELD("stringExcelField", "StringExcelField", null),
+        NUMBER_FIELD("numberField", "NumberField", null);
+        private final String field;
+        private final String displayName;
+        private final StyleDTO styles;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+        @Override public StyleDTO getStyles() { return styles; }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static ExcelSettings writeSettings(String sheetName) {
+        return ExcelSettings.builder().sheetName(sheetName).build();
+    }
+
+    private static ExcelReadSettings readSettings(String sheetName) {
+        return ExcelReadSettings.builder().sheetName(sheetName).build();
+    }
+
+    private static Date buildDate(int year, int month, int day) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month, day, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    /** Write a workbook to bytes and return them. */
+    private byte[] writeToBytes(Workbook wb) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        wb.close();
+        return out.toByteArray();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void readDynamicExcel_nullSheetName_throwsExcelGenerationException() {
+        ExcelReadSettings s = ExcelReadSettings.builder().build(); // sheetName null
+
+        try (Workbook wb = new XSSFWorkbook()) {
+            assertThrows(ExcelGenerationException.class,
+                    () -> service.readDynamicExcel(wb, Arrays.asList(PersonHeader.values()), PersonDTO.class, s));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void readDynamicExcel_sheetNotFound_throwsExcelGenerationException() {
+        ExcelReadSettings s = readSettings("DoesNotExist");
+
+        try (Workbook wb = new XSSFWorkbook()) {
+            wb.createSheet("OtherSheet");
+            assertThrows(ExcelGenerationException.class,
+                    () -> service.readDynamicExcel(wb, Arrays.asList(PersonHeader.values()), PersonDTO.class, s));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void readDynamicExcel_noDefaultConstructor_throwsExcelGenerationException() throws Exception {
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()),
+                Collections.singletonList(PersonDTO.builder().name("X").build()),
+                PersonDTO.class, writeSettings("S"));
+
+        assertThrows(ExcelGenerationException.class,
+                () -> service.readDynamicExcel(bytes, Arrays.asList(PersonHeader.values()),
+                        NoDefaultConstructorDTO.class, readSettings("S")));
+    }
+
+    @Test
+    void readDynamicExcel_noMatchingColumns_returnsEmptyList() throws Exception {
+        @AllArgsConstructor
+        class UnknownHeader implements ExcelHeaderBase {
+            @Override public String getField() { return "name"; }
+            @Override public String getDisplayName() { return "Completely Unknown Column"; }
+            @Override public StyleDTO getStyles() { return null; }
+        }
+
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()),
+                Collections.singletonList(PersonDTO.builder().name("Alice").build()),
+                PersonDTO.class, writeSettings("S"));
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Collections.singletonList(new UnknownHeader()), PersonDTO.class, readSettings("S"));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void readDynamicExcel_roundTrip_stringFields() throws Exception {
+        // Plain Double fields are written as STRING cells; round-trip uses string-only data
+        List<PersonDTO> original = Arrays.asList(
+                PersonDTO.builder().name("Alice").build(),
+                PersonDTO.builder().name("Bob").build());
+
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeSettings("S"));
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(2, result.size());
+        assertEquals("Alice", result.get(0).getName());
+        assertEquals("Bob", result.get(1).getName());
+    }
+
+    @Test
+    void readDynamicExcel_withRowOffset_readsCorrectly() throws Exception {
+        List<PersonDTO> original = Collections.singletonList(
+                PersonDTO.builder().name("Charlie").build());
+
+        ExcelSettings writeS = ExcelSettings.builder().sheetName("S").rowOffset(3).build();
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeS);
+
+        ExcelReadSettings readS = ExcelReadSettings.builder().sheetName("S").rowOffset(3).build();
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readS);
+
+        assertEquals(1, result.size());
+        assertEquals("Charlie", result.get(0).getName());
+    }
+
+    @Test
+    void readDynamicExcel_withColOffset_readsCorrectly() throws Exception {
+        List<PersonDTO> original = Collections.singletonList(
+                PersonDTO.builder().name("Dana").build());
+
+        ExcelSettings writeS = ExcelSettings.builder().sheetName("S").colOffset(2).build();
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeS);
+
+        ExcelReadSettings readS = ExcelReadSettings.builder().sheetName("S").colOffset(2).build();
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readS);
+
+        assertEquals(1, result.size());
+        assertEquals("Dana", result.get(0).getName());
+    }
+
+    @Test
+    void readDynamicExcel_searchKeys_findsTableByKeys() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        // Row 0: preamble
+        Row preamble = sheet.createRow(0);
+        preamble.createCell(0).setCellValue("Report Title");
+
+        // Row 1: empty
+        sheet.createRow(1);
+
+        // Row 2: header
+        Row header = sheet.createRow(2);
+        header.createCell(0).setCellValue("Name");
+        header.createCell(1).setCellValue("Amount");
+
+        // Row 3: data
+        Row data = sheet.createRow(3);
+        data.createCell(0).setCellValue("Eve");
+        data.createCell(1).setCellValue(99.0);
+
+        byte[] bytes = writeToBytes(wb);
+
+        ExcelReadSettings readS = ExcelReadSettings.builder()
+                .sheetName("S")
+                .searchKeys(Arrays.asList("Name", "Amount"))
+                .build();
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readS);
+
+        assertEquals(1, result.size());
+        assertEquals("Eve", result.get(0).getName());
+        assertEquals(99.0, result.get(0).getAmount(), 0.001);
+    }
+
+    @Test
+    void readDynamicExcel_searchKeysNotFound_throwsExcelGenerationException() throws Exception {
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()),
+                Collections.singletonList(PersonDTO.builder().name("X").build()),
+                PersonDTO.class, writeSettings("S"));
+
+        ExcelReadSettings readS = ExcelReadSettings.builder()
+                .sheetName("S")
+                .searchKeys(Arrays.asList("NonExistent", "Keys"))
+                .build();
+
+        assertThrows(ExcelGenerationException.class,
+                () -> service.readDynamicExcel(bytes, Arrays.asList(PersonHeader.values()),
+                        PersonDTO.class, readS));
+    }
+
+    @Test
+    void readDynamicExcel_searchKeys_maxScanRows_limitsSearch() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        // Header at row 5 — beyond the scan limit of 3
+        for (int i = 0; i < 5; i++) sheet.createRow(i);
+        Row header = sheet.createRow(5);
+        header.createCell(0).setCellValue("Name");
+        header.createCell(1).setCellValue("Amount");
+
+        byte[] bytes = writeToBytes(wb);
+
+        ExcelReadSettings readS = ExcelReadSettings.builder()
+                .sheetName("S")
+                .searchKeys(Arrays.asList("Name", "Amount"))
+                .maxScanRows(3)
+                .build();
+
+        assertThrows(ExcelGenerationException.class,
+                () -> service.readDynamicExcel(bytes, Arrays.asList(PersonHeader.values()),
+                        PersonDTO.class, readS));
+    }
+
+    @Test
+    void readDynamicExcel_emptyRows_areSkipped() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("Name");
+        header.createCell(1).setCellValue("Amount");
+
+        Row data1 = sheet.createRow(1);
+        data1.createCell(0).setCellValue("Alice");
+        data1.createCell(1).setCellValue(1.0);
+
+        // Row 2: empty (skip it)
+        sheet.createRow(2);
+
+        Row data3 = sheet.createRow(3);
+        data3.createCell(0).setCellValue("Bob");
+        data3.createCell(1).setCellValue(2.0);
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(2, result.size());
+        assertEquals("Alice", result.get(0).getName());
+        assertEquals("Bob", result.get(1).getName());
+    }
+
+    @Test
+    void readDynamicExcel_nullCell_fieldLeftNull() throws Exception {
+        List<PersonDTO> original = Collections.singletonList(
+                PersonDTO.builder().name("Fiona").build()); // amount is null
+
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeSettings("S"));
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals("Fiona", result.get(0).getName());
+        assertEquals(null, result.get(0).getAmount());
+    }
+
+    @Test
+    void readDynamicExcel_booleanCell_mappedToBoolean() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("StrField");
+        header.createCell(1).setCellValue("IntField");
+        header.createCell(2).setCellValue("LongField");
+        header.createCell(3).setCellValue("BoolField");
+        header.createCell(4).setCellValue("StringExcelField");
+        header.createCell(5).setCellValue("NumberField");
+
+        Row data = sheet.createRow(1);
+        data.createCell(3).setCellValue(true);
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<TypedDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(TypedHeader.values()), TypedDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals(Boolean.TRUE, result.get(0).getBoolField());
+    }
+
+    @Test
+    void readDynamicExcel_integerCell_mappedToInteger() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("StrField");
+        header.createCell(1).setCellValue("IntField");
+        header.createCell(2).setCellValue("LongField");
+        header.createCell(3).setCellValue("BoolField");
+        header.createCell(4).setCellValue("StringExcelField");
+        header.createCell(5).setCellValue("NumberField");
+
+        Row data = sheet.createRow(1);
+        data.createCell(1).setCellValue(42.0);
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<TypedDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(TypedHeader.values()), TypedDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals(Integer.valueOf(42), result.get(0).getIntField());
+    }
+
+    @Test
+    void readDynamicExcel_longCell_mappedToLong() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("StrField");
+        header.createCell(1).setCellValue("IntField");
+        header.createCell(2).setCellValue("LongField");
+        header.createCell(3).setCellValue("BoolField");
+        header.createCell(4).setCellValue("StringExcelField");
+        header.createCell(5).setCellValue("NumberField");
+
+        Row data = sheet.createRow(1);
+        data.createCell(2).setCellValue(1234567890.0);
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<TypedDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(TypedHeader.values()), TypedDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals(Long.valueOf(1234567890L), result.get(0).getLongField());
+    }
+
+    @Test
+    void readDynamicExcel_stringExcelField_mappedToStringExcel() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("StrField");
+        header.createCell(1).setCellValue("IntField");
+        header.createCell(2).setCellValue("LongField");
+        header.createCell(3).setCellValue("BoolField");
+        header.createCell(4).setCellValue("StringExcelField");
+        header.createCell(5).setCellValue("NumberField");
+
+        Row data = sheet.createRow(1);
+        data.createCell(4).setCellValue("HelloExcel");
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<TypedDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(TypedHeader.values()), TypedDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(0).getStringExcelField());
+        assertEquals("HelloExcel", result.get(0).getStringExcelField().getValue());
+    }
+
+    @Test
+    void readDynamicExcel_numberField_mappedToNumber() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("StrField");
+        header.createCell(1).setCellValue("IntField");
+        header.createCell(2).setCellValue("LongField");
+        header.createCell(3).setCellValue("BoolField");
+        header.createCell(4).setCellValue("StringExcelField");
+        header.createCell(5).setCellValue("NumberField");
+
+        Row data = sheet.createRow(1);
+        data.createCell(5).setCellValue(3.14);
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<TypedDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(TypedHeader.values()), TypedDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(0).getNumberField());
+        assertEquals(3.14, result.get(0).getNumberField().getValue(), 0.001);
+    }
+
+    @Test
+    void readDynamicExcel_formulaCell_evaluated() throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet("S");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("Name");
+        header.createCell(1).setCellValue("Amount");
+
+        Row data = sheet.createRow(1);
+        data.createCell(0).setCellValue("George");
+        data.createCell(1).setCellFormula("1+2");
+
+        byte[] bytes = writeToBytes(wb);
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals("George", result.get(0).getName());
+        assertEquals(3.0, result.get(0).getAmount(), 0.001);
+    }
+
+    @Test
+    void readDynamicExcel_fromByteArray_returnsValidList() throws Exception {
+        List<PersonDTO> original = Collections.singletonList(
+                PersonDTO.builder().name("Henry").build());
+
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeSettings("S"));
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(1, result.size());
+        assertEquals("Henry", result.get(0).getName());
+    }
+
+    @Test
+    void readDynamicExcel_multipleRows_allRead() throws Exception {
+        List<PersonDTO> original = Arrays.asList(
+                PersonDTO.builder().name("Iris").build(),
+                PersonDTO.builder().name("Jack").build(),
+                PersonDTO.builder().name("Kate").build());
+
+        byte[] bytes = service.generateDynamicExcel(
+                Arrays.asList(PersonHeader.values()), original, PersonDTO.class, writeSettings("S"));
+
+        List<PersonDTO> result = service.readDynamicExcel(bytes,
+                Arrays.asList(PersonHeader.values()), PersonDTO.class, readSettings("S"));
+
+        assertEquals(3, result.size());
+        assertEquals("Iris", result.get(0).getName());
+        assertEquals("Jack", result.get(1).getName());
+        assertEquals("Kate", result.get(2).getName());
+    }
+}

--- a/src/test/java/io/github/devcodehub/excel/lib/service/ExcelServiceImplWriteTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/service/ExcelServiceImplWriteTest.java
@@ -1,0 +1,379 @@
+package io.github.devcodehub.excel.lib.service;
+
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelSettings;
+import io.github.devcodehub.excel.lib.model.dto.excel.StyleDTO;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.DateExcel;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Merge;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Number;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.StringExcel;
+import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExcelServiceImplWriteTest {
+
+    private ExcelServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExcelServiceImpl();
+    }
+
+    // ── DTOs ──────────────────────────────────────────────────────────────────
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class BasicDTO {
+        private String name;
+        private Double amount;
+    }
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class AllTypesDTO {
+        private String plain;
+        private Boolean flag;
+        private Date date;
+        private StringExcel styled;
+        private Number num;
+        private DateExcel dateExcel;
+    }
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class MergeDTO {
+        private Merge mergeField;
+    }
+
+    // ── Headers ───────────────────────────────────────────────────────────────
+
+    @AllArgsConstructor
+    enum BasicHeader implements ExcelHeaderBase {
+        NAME("name", "Name", null),
+        AMOUNT("amount", "Amount", null);
+        private final String field;
+        private final String displayName;
+        private final StyleDTO styles;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+        @Override public StyleDTO getStyles() { return styles; }
+    }
+
+    @AllArgsConstructor
+    enum AllTypesHeader implements ExcelHeaderBase {
+        PLAIN("plain", "Plain", null),
+        FLAG("flag", "Flag", null),
+        DATE("date", "Date", null),
+        STYLED("styled", "Styled", null),
+        NUM("num", "Num", null),
+        DATE_EXCEL("dateExcel", "DateExcel", null);
+        private final String field;
+        private final String displayName;
+        private final StyleDTO styles;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+        @Override public StyleDTO getStyles() { return styles; }
+    }
+
+    @AllArgsConstructor
+    enum MergeHeader implements ExcelHeaderBase {
+        MERGE_FIELD("mergeField", "Merged", null);
+        private final String field;
+        private final String displayName;
+        private final StyleDTO styles;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+        @Override public StyleDTO getStyles() { return styles; }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static ExcelSettings settings(String sheetName) {
+        return ExcelSettings.builder().sheetName(sheetName).build();
+    }
+
+    private static List<BasicHeader> basicHeaders() {
+        return Arrays.asList(BasicHeader.values());
+    }
+
+    private static Date buildDate(int year, int month, int day) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month, day, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void generateDynamicExcelWorkbook_createsSheetWithGivenName() throws Exception {
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                basicHeaders(), Collections.emptyList(), BasicDTO.class, settings("MySheet"))) {
+            assertNotNull(wb.getSheet("MySheet"));
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_headerRow_atRowOffset() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Alice").build());
+        ExcelSettings s = ExcelSettings.builder().sheetName("S").rowOffset(2).build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, s)) {
+            Sheet sheet = wb.getSheet("S");
+            Row headerRow = sheet.getRow(2);
+            assertNotNull(headerRow);
+            assertEquals("Name", headerRow.getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_headerRow_containsDisplayNames() throws Exception {
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                basicHeaders(), Collections.emptyList(), BasicDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            Row header = sheet.getRow(0);
+            assertEquals("Name",   header.getCell(0).getStringCellValue());
+            assertEquals("Amount", header.getCell(1).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_dataRow_startsAtRowOffsetPlusOne() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Alice").amount(99.0).build());
+        ExcelSettings s = ExcelSettings.builder().sheetName("S").rowOffset(1).build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, s)) {
+            Sheet sheet = wb.getSheet("S");
+            Row dataRow = sheet.getRow(2);
+            assertNotNull(dataRow);
+            assertEquals("Alice", dataRow.getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_colOffset_shiftsAllColumns() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Bob").amount(10.0).build());
+        ExcelSettings s = ExcelSettings.builder().sheetName("S").colOffset(2).build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, s)) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals("Name",   sheet.getRow(0).getCell(2).getStringCellValue());
+            assertEquals("Bob",    sheet.getRow(1).getCell(2).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_stringField_writtenAsStringCell() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Charlie").build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals(CellType.STRING, sheet.getRow(1).getCell(0).getCellType());
+            assertEquals("Charlie", sheet.getRow(1).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_booleanField_writtenAsBooleanCell() throws Exception {
+        List<AllTypesDTO> data = Collections.singletonList(AllTypesDTO.builder().flag(true).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(AllTypesHeader.values()), data, AllTypesDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals(CellType.BOOLEAN, sheet.getRow(1).getCell(1).getCellType());
+            assertTrue(sheet.getRow(1).getCell(1).getBooleanCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_dateField_writtenAsFormattedString() throws Exception {
+        Date date = buildDate(2024, Calendar.JUNE, 10);
+        List<AllTypesDTO> data = Collections.singletonList(AllTypesDTO.builder().date(date).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(AllTypesHeader.values()), data, AllTypesDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals("2024/06/10", sheet.getRow(1).getCell(2).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_stringExcelField_writtenAsStringCell() throws Exception {
+        List<AllTypesDTO> data = Collections.singletonList(
+                AllTypesDTO.builder().styled(StringExcel.fromValue("Hello")).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(AllTypesHeader.values()), data, AllTypesDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals("Hello", sheet.getRow(1).getCell(3).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_numberField_writtenAsNumericCell() throws Exception {
+        List<AllTypesDTO> data = Collections.singletonList(
+                AllTypesDTO.builder().num(Number.fromValue(42.5)).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(AllTypesHeader.values()), data, AllTypesDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals(CellType.NUMERIC, sheet.getRow(1).getCell(4).getCellType());
+            assertEquals(42.5, sheet.getRow(1).getCell(4).getNumericCellValue(), 0.001);
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_dateExcelField_usesSpecifiedFormat() throws Exception {
+        Date date = buildDate(2024, Calendar.JUNE, 10);
+        List<AllTypesDTO> data = Collections.singletonList(
+                AllTypesDTO.builder().dateExcel(DateExcel.fromValue(date, "dd/MM/yyyy")).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(AllTypesHeader.values()), data, AllTypesDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals("10/06/2024", sheet.getRow(1).getCell(5).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_nullField_doesNotCreateCell() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Diana").build()); // amount null
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertNull(sheet.getRow(1).getCell(1)); // no cell for null amount
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_multipleRows_allWritten() throws Exception {
+        List<BasicDTO> data = Arrays.asList(
+                BasicDTO.builder().name("Alice").build(),
+                BasicDTO.builder().name("Bob").build(),
+                BasicDTO.builder().name("Carol").build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(basicHeaders(), data, BasicDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals("Alice", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals("Bob",   sheet.getRow(2).getCell(0).getStringCellValue());
+            assertEquals("Carol", sheet.getRow(3).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_autoFilter_setWhenEnabled() throws Exception {
+        ExcelSettings s = ExcelSettings.builder().sheetName("S").headerFilterActive(true).build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                basicHeaders(), Collections.emptyList(), BasicDTO.class, s)) {
+            Sheet sheet = wb.getSheet("S");
+            assertTrue(((XSSFSheet) sheet).getCTWorksheet().isSetAutoFilter());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_freezePane_applied() throws Exception {
+        ExcelSettings.FreezePane fp = ExcelSettings.FreezePane.builder().colSplit(1).rowSplit(1).build();
+        ExcelSettings s = ExcelSettings.builder().sheetName("S").freezePane(fp).build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                basicHeaders(), Collections.emptyList(), BasicDTO.class, s)) {
+            // Workbook created without exception and sheet exists — freeze pane applied via POI internals
+            assertNotNull(wb.getSheet("S"));
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_horizontalMerge_createsMergedRegion() throws Exception {
+        Merge merge = Merge.fromValue(2, 0, "Merged Value", Merge.Orientation.HORIZONTAL);
+        List<MergeDTO> data = Collections.singletonList(MergeDTO.builder().mergeField(merge).build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(MergeHeader.values()), data, MergeDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals(1, sheet.getNumMergedRegions());
+            assertEquals(0, sheet.getMergedRegion(0).getFirstColumn());
+            assertEquals(1, sheet.getMergedRegion(0).getLastColumn());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_verticalMerge_createsMergedRegion() throws Exception {
+        Merge merge = Merge.fromValue(2, 0, "Merged Value", Merge.Orientation.VERTICAL);
+        List<MergeDTO> data = Arrays.asList(
+                MergeDTO.builder().mergeField(merge).build(),
+                MergeDTO.builder().build());
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                Arrays.asList(MergeHeader.values()), data, MergeDTO.class, settings("S"))) {
+            Sheet sheet = wb.getSheet("S");
+            assertEquals(1, sheet.getNumMergedRegions());
+            assertEquals(1, sheet.getMergedRegion(0).getFirstRow());
+            assertEquals(2, sheet.getMergedRegion(0).getLastRow());
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_appendsToExistingWorkbook() throws Exception {
+        Workbook existingWorkbook = new XSSFWorkbook();
+        existingWorkbook.createSheet("Existing");
+        ExcelSettings s = ExcelSettings.builder().sheetName("New").build();
+
+        try (Workbook wb = service.generateDynamicExcelWorkbook(
+                basicHeaders(), Collections.emptyList(), BasicDTO.class, s, existingWorkbook)) {
+            assertNotNull(wb.getSheet("Existing"));
+            assertNotNull(wb.getSheet("New"));
+        }
+    }
+
+    @Test
+    void generateDynamicExcelWorkbook_nullSheetName_throwsExcelGenerationException() {
+        ExcelSettings s = ExcelSettings.builder().build(); // sheetName is null
+
+        assertThrows(ExcelGenerationException.class, () ->
+                service.generateDynamicExcelWorkbook(basicHeaders(), Collections.emptyList(), BasicDTO.class, s));
+    }
+
+    @Test
+    void generateDynamicExcel_returnsNonEmptyByteArray() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Test").build());
+
+        byte[] bytes = service.generateDynamicExcel(basicHeaders(), data, BasicDTO.class, settings("S"));
+
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 0);
+    }
+
+    @Test
+    void generateDynamicExcel_byteArray_isValidXlsxWorkbook() throws Exception {
+        List<BasicDTO> data = Collections.singletonList(BasicDTO.builder().name("Eve").amount(7.0).build());
+
+        byte[] bytes = service.generateDynamicExcel(basicHeaders(), data, BasicDTO.class, settings("Sheet1"));
+
+        try (Workbook wb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            assertEquals("Eve", wb.getSheet("Sheet1").getRow(1).getCell(0).getStringCellValue());
+        }
+    }
+}

--- a/src/test/java/io/github/devcodehub/excel/lib/service/StyleServiceTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/service/StyleServiceTest.java
@@ -1,0 +1,162 @@
+package io.github.devcodehub.excel.lib.service;
+
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelColor;
+import io.github.devcodehub.excel.lib.model.dto.excel.ExcelCustomStyles;
+import io.github.devcodehub.excel.lib.model.dto.excel.StyleDTO;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.DateExcel;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Merge;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.Number;
+import io.github.devcodehub.excel.lib.model.dto.excel.datatype.StringExcel;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.VerticalAlignment;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class StyleServiceTest {
+
+    private Workbook workbook;
+    private ExcelCustomStyles defaultCustomStyles;
+
+    @BeforeEach
+    void setUp() {
+        workbook = new XSSFWorkbook();
+        defaultCustomStyles = ExcelCustomStyles.builder().build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        workbook.close();
+    }
+
+    @Test
+    void constructor_headerCellStyle_isNotNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getHeaderCellStyle());
+    }
+
+    @Test
+    void constructor_dataCellStyle_isNotNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getDataCellStyle());
+    }
+
+    @Test
+    void getHeaderCellStyle_withNullStyleDTO_returnsSameDefaultInstance() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        CellStyle result = service.getHeaderCellStyle(workbook, null);
+
+        assertSame(service.getHeaderCellStyle(), result);
+    }
+
+    @Test
+    void getCellStyle_forStringExcel_withNullStyleDTO_returnsNonNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getCellStyle(workbook, StringExcel.class, null));
+    }
+
+    @Test
+    void getCellStyle_forNumber_withNullStyleDTO_returnsNonNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getCellStyle(workbook, Number.class, null));
+    }
+
+    @Test
+    void getCellStyle_forDateExcel_withNullStyleDTO_returnsNonNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getCellStyle(workbook, DateExcel.class, null));
+    }
+
+    @Test
+    void getCellStyle_forMerge_withNullStyleDTO_returnsNonNull() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+
+        assertNotNull(service.getCellStyle(workbook, Merge.class, null));
+    }
+
+    @Test
+    void getNewCellStyle_bold_appliedToFont() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+        StyleDTO styleDTO = StyleDTO.builder().bold(true).build();
+
+        CellStyle style = service.getCellStyle(workbook, StringExcel.class, styleDTO);
+
+        Font font = workbook.getFontAt(style.getFontIndex());
+        assertEquals(true, font.getBold());
+    }
+
+    @Test
+    void getNewCellStyle_fontHeight_appliedToFont() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+        StyleDTO styleDTO = StyleDTO.builder().fontHeight(16.0).build();
+
+        CellStyle style = service.getCellStyle(workbook, StringExcel.class, styleDTO);
+
+        Font font = workbook.getFontAt(style.getFontIndex());
+        assertEquals(16, font.getFontHeightInPoints());
+    }
+
+    @Test
+    void getNewCellStyle_horizontalAlignment_applied() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+        StyleDTO styleDTO = StyleDTO.builder().horizontalAlignment(HorizontalAlignment.LEFT).build();
+
+        CellStyle style = service.getCellStyle(workbook, StringExcel.class, styleDTO);
+
+        assertEquals(HorizontalAlignment.LEFT, style.getAlignment());
+    }
+
+    @Test
+    void getNewCellStyle_verticalAlignment_applied() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+        StyleDTO styleDTO = StyleDTO.builder().verticalAlignment(VerticalAlignment.TOP).build();
+
+        CellStyle style = service.getCellStyle(workbook, StringExcel.class, styleDTO);
+
+        assertEquals(VerticalAlignment.TOP, style.getVerticalAlignment());
+    }
+
+    @Test
+    void getNewCellStyle_foregroundColor_setsSolidForeground() {
+        StyleService service = new StyleService(workbook, defaultCustomStyles);
+        StyleDTO styleDTO = StyleDTO.builder().foregroundColor(ExcelColor.LIGHT_BLUE).build();
+
+        CellStyle style = service.getCellStyle(workbook, StringExcel.class, styleDTO);
+
+        assertEquals(FillPatternType.SOLID_FOREGROUND, style.getFillPattern());
+    }
+
+    @Test
+    void defaultCustomStyles_headerBorderActive_producesNonNoneBorder() {
+        ExcelCustomStyles styles = ExcelCustomStyles.builder().headerBorderActive(true).build();
+        StyleService service = new StyleService(workbook, styles);
+
+        assertNotEquals(BorderStyle.NONE, service.getHeaderCellStyle().getBorderTop());
+    }
+
+    @Test
+    void defaultCustomStyles_customFontFamily_reflectedInFont() {
+        ExcelCustomStyles styles = ExcelCustomStyles.builder().fontFamily("Times New Roman").build();
+        StyleService service = new StyleService(workbook, styles);
+
+        Font font = workbook.getFontAt(service.getHeaderCellStyle().getFontIndex());
+        assertEquals("Times New Roman", font.getFontName());
+    }
+}

--- a/src/test/java/io/github/devcodehub/excel/lib/utils/DateUtilsTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/utils/DateUtilsTest.java
@@ -1,0 +1,50 @@
+package io.github.devcodehub.excel.lib.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DateUtilsTest {
+
+    @Test
+    void getDateAsString_nullDate_returnsNull() {
+        assertNull(DateUtils.getDateAsString(null));
+    }
+
+    @Test
+    void getDateAsString_nullDate_withCustomPattern_returnsNull() {
+        assertNull(DateUtils.getDateAsString(null, "dd-MM-yyyy"));
+    }
+
+    @Test
+    void getDateAsString_defaultFormat_producesCorrectString() {
+        Date date = buildDate(2024, Calendar.JANUARY, 15);
+
+        assertEquals("2024/01/15", DateUtils.getDateAsString(date));
+    }
+
+    @Test
+    void getDateAsString_customFormat_producesCorrectString() {
+        Date date = buildDate(2024, Calendar.MARCH, 5);
+
+        assertEquals("05-03-2024", DateUtils.getDateAsString(date, "dd-MM-yyyy"));
+    }
+
+    @Test
+    void defaultDateFormat_constant_matchesExpectedPattern() {
+        assertEquals("yyyy/MM/dd", DateUtils.DEFAULT_DATE_FORMAT);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static Date buildDate(int year, int month, int day) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month, day, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+}

--- a/src/test/java/io/github/devcodehub/excel/lib/utils/ExcelUtilsTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/utils/ExcelUtilsTest.java
@@ -1,0 +1,46 @@
+package io.github.devcodehub.excel.lib.utils;
+
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExcelUtilsTest {
+
+    @Test
+    void cloneFont_isNotSameInstance() throws Exception {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Font original = wb.createFont();
+
+            Font cloned = ExcelUtils.cloneFont(wb, original);
+
+            assertNotSame(original, cloned);
+        }
+    }
+
+    @Test
+    void cloneFont_copiesAllProperties() throws Exception {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Font original = wb.createFont();
+            original.setFontName("Arial");
+            original.setFontHeightInPoints((short) 14);
+            original.setBold(true);
+            original.setItalic(true);
+            original.setStrikeout(true);
+            original.setUnderline(Font.U_SINGLE);
+
+            Font cloned = ExcelUtils.cloneFont(wb, original);
+
+            assertEquals("Arial", cloned.getFontName());
+            assertEquals(14, cloned.getFontHeightInPoints());
+            assertTrue(cloned.getBold());
+            assertTrue(cloned.getItalic());
+            assertTrue(cloned.getStrikeout());
+            assertEquals(Font.U_SINGLE, cloned.getUnderline());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add bidirectional Excel read support (`readDynamicExcel`) — parses sheets back into typed DTO lists via reflection, with header location by content (`searchKeys`) or fixed offset
- Add 62 unit tests covering write, read, styling, and utility classes with real in-memory POI workbooks (no mocking)
- Rewrite README with complete bilingual (EN/PT) documentation for both write and read APIs
- Fix Maven plugin warnings and add Javadoc to `ExcelService` interface
- Add and expand `CLAUDE.md` with architecture docs, public API signatures, supported types, and test fixture inventory
## What a reviewer should know
- The read flow uses reflection + `FormulaEvaluator` and requires a no-args constructor on the target DTO class; rows that fail to map are skipped (not fatal)
- `central-publishing-maven-plugin` is configured with `autoPublish=true` — deploying with `-Prelease` publishes directly to Maven Central without a manual release step
- `distributionManagement` still references the legacy OSSRH URLs but is unused by the Central plugin; safe to remove in a follow-up