### PR TITLE
Feat: add CSV support (write + read)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
 			<version>5.3.0</version>
 		</dependency>
 
+		<!-- Commons Csv -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.12.0</version>
+		</dependency>
+
 		<!-- Spring Framework -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -74,6 +81,12 @@
 			<version>2.13.5</version>
 			<scope>compile</scope>
 		</dependency>
+
+<!--		<dependency>-->
+<!--			<groupId>jakarta.json</groupId>-->
+<!--			<artifactId>jakarta.json-api</artifactId>-->
+<!--			<version>2.0.1</version>-->
+<!--		</dependency>-->
 
 		<!-- Logger -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>commons-csv</artifactId>
 			<version>1.12.0</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.17.0</version>
+		</dependency>
 
 		<!-- Spring Framework -->
 		<dependency>

--- a/src/main/java/io/github/devcodehub/excel/lib/config/LibAutoConfiguration.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/config/LibAutoConfiguration.java
@@ -2,6 +2,8 @@ package io.github.devcodehub.excel.lib.config;
 
 import io.github.devcodehub.excel.lib.service.ExcelService;
 import io.github.devcodehub.excel.lib.service.ExcelServiceImpl;
+import io.github.devcodehub.excel.lib.service.csv.CsvService;
+import io.github.devcodehub.excel.lib.service.csv.CsvServiceImpl;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
@@ -12,5 +14,11 @@ public class LibAutoConfiguration {
     @Lazy
     public ExcelService excelService() {
         return new ExcelServiceImpl();
+    }
+
+    @Bean
+    @Lazy
+    public CsvService csvService() {
+        return new CsvServiceImpl();
     }
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/csv/CsvHeaderBase.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/csv/CsvHeaderBase.java
@@ -1,0 +1,7 @@
+package io.github.devcodehub.excel.lib.model.dto.csv;
+
+public interface CsvHeaderBase {
+    String getField();
+
+    String getDisplayName();
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/csv/CsvSettings.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/csv/CsvSettings.java
@@ -1,0 +1,22 @@
+package io.github.devcodehub.excel.lib.model.dto.csv;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CsvSettings {
+    @Builder.Default
+    private char delimiter = ';';
+    @Builder.Default
+    private Charset charset = StandardCharsets.UTF_8;
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/example/csv/CsvExampleDTO.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/example/csv/CsvExampleDTO.java
@@ -1,0 +1,23 @@
+package io.github.devcodehub.excel.lib.model.dto.example.csv;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * This class represents a row in the Csv Example
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CsvExampleDTO {
+
+    private String value1;
+    private String value2;
+    private Integer value3;
+    private double value4;
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/example/csv/CsvExampleHeader.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/example/csv/CsvExampleHeader.java
@@ -1,0 +1,26 @@
+package io.github.devcodehub.excel.lib.model.dto.example.csv;
+
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvHeaderBase;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CsvExampleHeader implements CsvHeaderBase {
+    VALUE1("value1", "Display Column 1"),
+    VALUE2("value2", "Display Column 2"),
+    VALUE3("value3", "Display Column 3"),
+    VALUE4("value4", "Display Column 4"),
+    ;
+
+    private final String field;
+    private final String displayName;
+
+    @Override
+    public String getField() {
+        return field;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/CsvGenerationException.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/CsvGenerationException.java
@@ -1,0 +1,13 @@
+package io.github.devcodehub.excel.lib.model.dto.exception;
+
+public class CsvGenerationException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public CsvGenerationException(String message) {
+        super(message);
+    }
+
+    public CsvGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ResponseCode.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ResponseCode.java
@@ -18,7 +18,8 @@ public enum ResponseCode {
 
     // Http code 500-599 - Server error responses
     INTERNAL_SERVER_ERROR(500, 0, "Internal Server Error"),
-    ERROR_GENERATING_DYNAMIC_EXCEL(500, 15, "Error generating dynamic excel"),
+    ERROR_GENERATING_DYNAMIC_EXCEL(500, 1, "Error generating dynamic excel"),
+    ERROR_GENERATING_CSV(500, 2, "Error generating csv"),
     NOT_IMPLEMENTED(501, 0, "Not Implemented"),
     UNAVAILABLE(503, 0, "Unavailable");
 

--- a/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ResponseCode.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/model/dto/exception/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
     INTERNAL_SERVER_ERROR(500, 0, "Internal Server Error"),
     ERROR_GENERATING_DYNAMIC_EXCEL(500, 1, "Error generating dynamic excel"),
     ERROR_GENERATING_CSV(500, 2, "Error generating csv"),
+    ERROR_READING_CSV(500, 3, "Error reading csv"),
     NOT_IMPLEMENTED(501, 0, "Not Implemented"),
     UNAVAILABLE(503, 0, "Unavailable");
 

--- a/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/ExcelServiceImpl.java
@@ -11,6 +11,7 @@ import io.github.devcodehub.excel.lib.model.dto.excel.datatype.StringExcel;
 import io.github.devcodehub.excel.lib.model.dto.exception.ExcelGenerationException;
 import io.github.devcodehub.excel.lib.model.dto.exception.ResponseCode;
 import io.github.devcodehub.excel.lib.utils.DateUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
@@ -22,8 +23,6 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -41,14 +40,14 @@ import java.util.Map;
 import java.util.Set;
 
 @Lazy
+@Slf4j
 @Service
 public class ExcelServiceImpl implements ExcelService {
     private static final int POI_DEFAULT_UNIT = 256;
     private static final int DEFAULT_COLUMN_WIDTH = 10 * POI_DEFAULT_UNIT;
     private static final int MAX_COLUMN_WIDTH = 255 * POI_DEFAULT_UNIT;
     private static final int DEFAULT_COLUMN_MARGIN = 5 * POI_DEFAULT_UNIT;
-
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private StyleService styleService;
 
     // ── Write ─────────────────────────────────────────────────────────────────
 

--- a/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvService.java
@@ -1,0 +1,15 @@
+package io.github.devcodehub.excel.lib.service.csv;
+
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvSettings;
+import io.github.devcodehub.excel.lib.model.dto.exception.CsvGenerationException;
+
+import java.util.List;
+
+public interface CsvService {
+
+    byte[] generateCsv(List<? extends CsvHeaderBase> headers,
+                       List<?> data,
+                       Class<?> dataClass,
+                       CsvSettings settings) throws CsvGenerationException;
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvService.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvService.java
@@ -12,4 +12,9 @@ public interface CsvService {
                        List<?> data,
                        Class<?> dataClass,
                        CsvSettings settings) throws CsvGenerationException;
+
+    <T> List<T> readCsv(byte[] csv,
+                        List<? extends CsvHeaderBase> headers,
+                        Class<T> dataClass,
+                        CsvSettings settings) throws CsvGenerationException;
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvServiceImpl.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvServiceImpl.java
@@ -1,0 +1,57 @@
+package io.github.devcodehub.excel.lib.service.csv;
+
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvSettings;
+import io.github.devcodehub.excel.lib.model.dto.exception.CsvGenerationException;
+import io.github.devcodehub.excel.lib.model.dto.exception.ResponseCode;
+import io.github.devcodehub.excel.lib.utils.CsvHeaderUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.util.CollectionUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class CsvServiceImpl implements CsvService {
+
+    @Override
+    public byte[] generateCsv(List<? extends CsvHeaderBase> headers,
+                               List<?> data,
+                               Class<?> dataClass,
+                               CsvSettings settings) throws CsvGenerationException {
+        if (CollectionUtils.isEmpty(data)) {
+            throw new CsvGenerationException(ResponseCode.ERROR_GENERATING_CSV.getMessage());
+        }
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             OutputStreamWriter writer = new OutputStreamWriter(outputStream, settings.getCharset());
+             CSVPrinter csvPrinter = new CSVPrinter(writer,
+                     CSVFormat.Builder.create()
+                             .setHeader(CsvHeaderUtils.getDisplayNames(headers))
+                             .setDelimiter(settings.getDelimiter())
+                             .build())) {
+
+            for (Object dto : data) {
+                List<Object> values = new ArrayList<>();
+                for (CsvHeaderBase header : headers) {
+                    Field field = dataClass.getDeclaredField(header.getField());
+                    field.setAccessible(true);
+                    values.add(field.get(dto));
+                }
+                csvPrinter.printRecord(values);
+            }
+
+            csvPrinter.flush();
+            return outputStream.toByteArray();
+        } catch (IOException | NoSuchFieldException | IllegalAccessException e) {
+            log.error("Error generating CSV file", e);
+            throw new CsvGenerationException(ResponseCode.ERROR_GENERATING_CSV.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvServiceImpl.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/service/csv/CsvServiceImpl.java
@@ -7,15 +7,21 @@ import io.github.devcodehub.excel.lib.model.dto.exception.ResponseCode;
 import io.github.devcodehub.excel.lib.utils.CsvHeaderUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
 import org.springframework.util.CollectionUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class CsvServiceImpl implements CsvService {
@@ -52,6 +58,101 @@ public class CsvServiceImpl implements CsvService {
         } catch (IOException | NoSuchFieldException | IllegalAccessException e) {
             log.error("Error generating CSV file", e);
             throw new CsvGenerationException(ResponseCode.ERROR_GENERATING_CSV.getMessage(), e);
+        }
+    }
+
+    @Override
+    public <T> List<T> readCsv(byte[] csv,
+                                List<? extends CsvHeaderBase> headers,
+                                Class<T> dataClass,
+                                CsvSettings settings) throws CsvGenerationException {
+        final java.lang.reflect.Constructor<T> noArgsCtor;
+        try {
+            noArgsCtor = dataClass.getDeclaredConstructor();
+            noArgsCtor.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new CsvGenerationException(dataClass.getName() + " must have a no-args constructor.", e);
+        }
+
+        Map<String, CsvHeaderBase> byDisplayName = new HashMap<>();
+        for (CsvHeaderBase header : headers) {
+            byDisplayName.put(header.getDisplayName(), header);
+        }
+
+        try (InputStreamReader reader = new InputStreamReader(new ByteArrayInputStream(csv), settings.getCharset());
+             CSVParser csvParser = new CSVParser(reader,
+                     CSVFormat.Builder.create()
+                             .setDelimiter(settings.getDelimiter())
+                             .build())) {
+
+            List<CSVRecord> records = csvParser.getRecords();
+            if (records.isEmpty()) {
+                return new ArrayList<>();
+            }
+
+            // First record is the header row — build column index → header mapping
+            CSVRecord headerRecord = records.get(0);
+            Map<Integer, CsvHeaderBase> columnMapping = new HashMap<>();
+            for (int i = 0; i < headerRecord.size(); i++) {
+                CsvHeaderBase header = byDisplayName.get(headerRecord.get(i).trim());
+                if (header != null) {
+                    columnMapping.put(i, header);
+                }
+            }
+
+            if (columnMapping.isEmpty()) {
+                log.warn("No columns matched the provided headers. Returning empty list.");
+                return new ArrayList<>();
+            }
+
+            List<T> result = new ArrayList<>();
+
+            for (int r = 1; r < records.size(); r++) {
+                CSVRecord record = records.get(r);
+                try {
+                    T instance = noArgsCtor.newInstance();
+                    boolean hasData = false;
+
+                    for (Map.Entry<Integer, CsvHeaderBase> entry : columnMapping.entrySet()) {
+                        if (entry.getKey() >= record.size()) continue;
+                        String rawValue = record.get(entry.getKey());
+                        if (rawValue == null || rawValue.isEmpty()) continue;
+
+                        Field field = dataClass.getDeclaredField(entry.getValue().getField());
+                        field.setAccessible(true);
+                        Object value = convertValue(rawValue, field.getType());
+                        if (value != null) {
+                            field.set(instance, value);
+                            hasData = true;
+                        }
+                    }
+
+                    if (hasData) result.add(instance);
+                } catch (ReflectiveOperationException e) {
+                    log.warn("Skipping record {}: could not map to {}", r + 1, dataClass.getSimpleName(), e);
+                }
+            }
+
+            log.info("Read {} records from CSV", result.size());
+            return result;
+        } catch (IOException e) {
+            log.error("Error reading CSV file", e);
+            throw new CsvGenerationException(ResponseCode.ERROR_READING_CSV.getMessage(), e);
+        }
+    }
+
+    private Object convertValue(String value, Class<?> targetType) {
+        try {
+            if (targetType == String.class) return value;
+            if (targetType == Integer.class || targetType == int.class) return Integer.parseInt(value.trim());
+            if (targetType == Long.class || targetType == long.class) return Long.parseLong(value.trim());
+            if (targetType == Double.class || targetType == double.class) return Double.parseDouble(value.trim());
+            if (targetType == Float.class || targetType == float.class) return Float.parseFloat(value.trim());
+            if (targetType == Boolean.class || targetType == boolean.class) return Boolean.parseBoolean(value.trim());
+            return value;
+        } catch (NumberFormatException e) {
+            log.warn("Could not convert '{}' to {}", value, targetType.getSimpleName());
+            return null;
         }
     }
 }

--- a/src/main/java/io/github/devcodehub/excel/lib/utils/CsvHeaderUtils.java
+++ b/src/main/java/io/github/devcodehub/excel/lib/utils/CsvHeaderUtils.java
@@ -1,0 +1,15 @@
+package io.github.devcodehub.excel.lib.utils;
+
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvHeaderBase;
+
+import java.util.List;
+
+public class CsvHeaderUtils {
+    private CsvHeaderUtils() {}
+
+    public static String[] getDisplayNames(List<? extends CsvHeaderBase> headers) {
+        return headers.stream()
+                      .map(CsvHeaderBase::getDisplayName)
+                      .toArray(String[]::new);
+    }
+}

--- a/src/test/java/io/github/devcodehub/excel/lib/service/CsvServiceImplTest.java
+++ b/src/test/java/io/github/devcodehub/excel/lib/service/CsvServiceImplTest.java
@@ -1,0 +1,213 @@
+package io.github.devcodehub.excel.lib.service;
+
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvHeaderBase;
+import io.github.devcodehub.excel.lib.model.dto.csv.CsvSettings;
+import io.github.devcodehub.excel.lib.model.dto.exception.CsvGenerationException;
+import io.github.devcodehub.excel.lib.service.csv.CsvServiceImpl;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CsvServiceImplTest {
+
+    private CsvServiceImpl service;
+    private CsvSettings defaultSettings;
+
+    @BeforeEach
+    void setUp() {
+        service = new CsvServiceImpl();
+        defaultSettings = CsvSettings.builder().build();
+    }
+
+    // ── DTOs ──────────────────────────────────────────────────────────────────
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class PersonDTO {
+        private String name;
+        private Integer age;
+    }
+
+    @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+    static class AllTypesDTO {
+        private String strField;
+        private Integer intField;
+        private Long longField;
+        private Double doubleField;
+        private Float floatField;
+        private Boolean boolField;
+    }
+
+    static class NoDefaultConstructorDTO {
+        private final String value;
+        NoDefaultConstructorDTO(String value) { this.value = value; }
+    }
+
+    // ── Headers ───────────────────────────────────────────────────────────────
+
+    @AllArgsConstructor
+    enum PersonHeader implements CsvHeaderBase {
+        NAME("name", "Name"),
+        AGE("age", "Age"),
+        ;
+        private final String field;
+        private final String displayName;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+    }
+
+    @AllArgsConstructor
+    enum AllTypesHeader implements CsvHeaderBase {
+        STR("strField", "String"),
+        INT("intField", "Integer"),
+        LONG("longField", "Long"),
+        DOUBLE("doubleField", "Double"),
+        FLOAT("floatField", "Float"),
+        BOOL("boolField", "Boolean"),
+        ;
+        private final String field;
+        private final String displayName;
+        @Override public String getField() { return field; }
+        @Override public String getDisplayName() { return displayName; }
+    }
+
+    // ── generateCsv ───────────────────────────────────────────────────────────
+
+    @Test
+    void generateCsv_producesHeaderRowAndDataRow() throws CsvGenerationException {
+        List<PersonDTO> data = Arrays.asList(
+                PersonDTO.builder().name("Alice").age(30).build(),
+                PersonDTO.builder().name("Bob").age(25).build()
+        );
+
+        byte[] result = service.generateCsv(
+                Arrays.asList(PersonHeader.values()), data, PersonDTO.class, defaultSettings);
+
+        String csv = new String(result, StandardCharsets.UTF_8);
+        assertTrue(csv.contains("Name"));
+        assertTrue(csv.contains("Age"));
+        assertTrue(csv.contains("Alice"));
+        assertTrue(csv.contains("30"));
+        assertTrue(csv.contains("Bob"));
+        assertTrue(csv.contains("25"));
+    }
+
+    @Test
+    void generateCsv_emptyData_throwsCsvGenerationException() {
+        assertThrows(CsvGenerationException.class, () ->
+                service.generateCsv(Arrays.asList(PersonHeader.values()),
+                        Collections.emptyList(), PersonDTO.class, defaultSettings));
+    }
+
+    @Test
+    void generateCsv_customDelimiter_usesDelimiterInOutput() throws CsvGenerationException {
+        CsvSettings commaSettings = CsvSettings.builder().delimiter(',').build();
+        List<PersonDTO> data = Collections.singletonList(
+                PersonDTO.builder().name("Alice").age(30).build());
+
+        byte[] result = service.generateCsv(
+                Arrays.asList(PersonHeader.values()), data, PersonDTO.class, commaSettings);
+
+        String csv = new String(result, StandardCharsets.UTF_8);
+        assertTrue(csv.contains("Name,Age"));
+    }
+
+    // ── readCsv ───────────────────────────────────────────────────────────────
+
+    @Test
+    void readCsv_roundTrip_returnsOriginalData() throws CsvGenerationException {
+        List<PersonDTO> original = Arrays.asList(
+                PersonDTO.builder().name("Alice").age(30).build(),
+                PersonDTO.builder().name("Bob").age(25).build()
+        );
+        List<? extends CsvHeaderBase> headers = Arrays.asList(PersonHeader.values());
+
+        byte[] csv = service.generateCsv(headers, original, PersonDTO.class, defaultSettings);
+        List<PersonDTO> result = service.readCsv(csv, headers, PersonDTO.class, defaultSettings);
+
+        assertEquals(2, result.size());
+        assertEquals("Alice", result.get(0).getName());
+        assertEquals(30, result.get(0).getAge());
+        assertEquals("Bob", result.get(1).getName());
+        assertEquals(25, result.get(1).getAge());
+    }
+
+    @Test
+    void readCsv_columnOrderIndependent_mapsCorrectly() throws CsvGenerationException {
+        // CSV with columns in reversed order: Age;Name
+        String csv = "Age;Name\r\n30;Alice\r\n25;Bob\r\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        List<PersonDTO> result = service.readCsv(
+                bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, defaultSettings);
+
+        assertEquals(2, result.size());
+        assertEquals("Alice", result.get(0).getName());
+        assertEquals(30, result.get(0).getAge());
+    }
+
+    @Test
+    void readCsv_allSupportedTypes_convertsCorrectly() throws CsvGenerationException {
+        String csv = "String;Integer;Long;Double;Float;Boolean\r\nhello;42;9876543210;3.14;1.5;true\r\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        List<AllTypesDTO> result = service.readCsv(
+                bytes, Arrays.asList(AllTypesHeader.values()), AllTypesDTO.class, defaultSettings);
+
+        assertEquals(1, result.size());
+        AllTypesDTO dto = result.get(0);
+        assertEquals("hello", dto.getStrField());
+        assertEquals(42, dto.getIntField());
+        assertEquals(9876543210L, dto.getLongField());
+        assertEquals(3.14, dto.getDoubleField(), 0.001);
+        assertEquals(1.5f, dto.getFloatField(), 0.001f);
+        assertTrue(dto.getBoolField());
+    }
+
+    @Test
+    void readCsv_missingNoArgsConstructor_throwsCsvGenerationException() {
+        String csv = "Name;Age\r\nAlice;30\r\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(CsvGenerationException.class, () ->
+                service.readCsv(bytes, Arrays.asList(PersonHeader.values()),
+                        NoDefaultConstructorDTO.class, defaultSettings));
+    }
+
+    @Test
+    void readCsv_unknownColumnInFile_isIgnored() throws CsvGenerationException {
+        // CSV has an extra column "Email" not in the header enum
+        String csv = "Name;Age;Email\r\nAlice;30;alice@example.com\r\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        List<PersonDTO> result = service.readCsv(
+                bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, defaultSettings);
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(0).getName());
+    }
+
+    @Test
+    void readCsv_emptyCsv_returnsEmptyList() throws CsvGenerationException {
+        String csv = "Name;Age\r\n";
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+
+        List<PersonDTO> result = service.readCsv(
+                bytes, Arrays.asList(PersonHeader.values()), PersonDTO.class, defaultSettings);
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CsvService` / `CsvServiceImpl` with **write** (`generateCsv`) and **read** (`readCsv`) support using Apache Commons CSV
- Reflection-based API — no interface required on data POJOs (mirrors `ExcelService` design)
- `CsvHeaderBase` interface with `getField()` + `getDisplayName()`, `CsvSettings` with configurable `delimiter` (default `;`) and `charset` (default UTF-8)
- `CsvGenerationException` (typed checked exception, mirrors `ExcelGenerationException`)
- 9 tests in `CsvServiceImplTest` covering write, round-trip read, column-order independence, all supported types, edge cases

## What changed

| Area | Change |
|---|---|
| `model/dto/csv/CsvHeaderBase` | New — proper location for the header contract (`getField` + `getDisplayName`) |
| `model/dto/csv/CsvSettings` | New — configurable delimiter and charset |
| `model/dto/exception/CsvGenerationException` | New — typed checked exception |
| `service/csv/CsvService` | Write + read API; `throws CsvGenerationException` |
| `service/csv/CsvServiceImpl` | Full implementation with reflection, try-with-resources, constructor `setAccessible(true)` |
| `utils/CsvHeaderUtils` | Private constructor added; method updated to accept `List<>` |
| `config/LibAutoConfiguration` | `@Lazy` added to `csvService()` bean |
| `pom.xml` | `commons-io 2.17.0` explicit dependency (commons-csv 1.12.0 requires `UnsynchronizedBufferedReader` added in 2.17.0; POI transitively provided only 2.16.1) |
| `model/dto/example/csv/` | `CsvExampleDTO` and `CsvExampleHeader` updated to plain POJO + new interface; `CsvDTOBase` and old `CsvHeaderBase` removed |

## Reviewer notes

- `readCsv` maps columns by display name (column-order independent), consistent with `readDynamicExcel`
- Per-row mapping failures are non-fatal (logged + skipped), same behaviour as the Excel read path
- The `constructor.setAccessible(true)` call is needed to support non-public DTO classes across packages on Java 9+

## Test plan

- [x] `mvn test` — full suite green
- [x] `CsvServiceImplTest` — 9 tests: write, read round-trip, column order independence, all types, missing constructor, unknown column, empty CSV